### PR TITLE
BIP329 import

### DIFF
--- a/src/accounting.rs
+++ b/src/accounting.rs
@@ -1,6 +1,6 @@
 use std::collections::VecDeque;
 
-use anyhow::{Result, Context, bail};
+use anyhow::{Context, Result, bail};
 use chrono::{DateTime, Datelike, NaiveDate, Utc};
 
 use crate::exchange_rate::ExchangeRateProvider;
@@ -61,7 +61,8 @@ pub fn build_statement(
     // When getbalance is available, compute the opening balance backwards from it.
     // This is more reliable than forward replay of pre-start transactions, which can
     // be thrown off by RBF transactions, self-sends, and other wallet quirks.
-    let backwards_opening_sats: Option<i64> = if let Some(wallet_sats) = config.wallet_balance_sats {
+    let backwards_opening_sats: Option<i64> = if let Some(wallet_sats) = config.wallet_balance_sats
+    {
         let mut backwards_sats = wallet_sats;
         let mut back_fee_txids = std::collections::HashSet::new();
         for tx in transactions.iter().rev() {
@@ -111,10 +112,12 @@ pub fn build_statement(
             if config.fiat_mode && opening_sats != 0 {
                 if let Some(start) = config.start_date {
                     let start_ts = start.and_hms_opt(0, 0, 0).unwrap().and_utc().timestamp();
-                    let rate = provider.get_vwap(start_ts, config.candle_interval_minutes)
+                    let rate = provider
+                        .get_vwap(start_ts, config.candle_interval_minutes)
                         .context("failed to get rate at start_date for opening balance")?;
                     opening_rate = Some(rate);
-                    balance_cents = config.opening_balance_cents + convert_to_cents(opening_sats, Some(rate));
+                    balance_cents =
+                        config.opening_balance_cents + convert_to_cents(opening_sats, Some(rate));
                 }
             }
             computed_opening_balance = Some(balance_cents);
@@ -156,8 +159,13 @@ pub fn build_statement(
 
         let booking_date = timestamp_to_date_string(tx.block_time)?;
         let rate_cents_per_btc = if config.fiat_mode {
-            Some(provider.get_vwap(tx.block_time, config.candle_interval_minutes)
-                .with_context(|| format!("failed to get rate for tx {} at {}", tx.txid, tx.block_time))?)
+            Some(
+                provider
+                    .get_vwap(tx.block_time, config.candle_interval_minutes)
+                    .with_context(|| {
+                        format!("failed to get rate for tx {} at {}", tx.txid, tx.block_time)
+                    })?,
+            )
         } else {
             None
         };
@@ -178,9 +186,24 @@ pub fn build_statement(
                 let entry_ref = format_entry_ref(tx.block_height, &tx.txid, tx.vout);
                 let full_ref = format_full_ref(&tx.block_hash, &tx.txid, tx.vout);
 
-                let label = if tx.address.is_empty() { "" } else if tx.label.is_empty() { &tx.address } else { &tx.label };
-                let hash_suffix = tx.payment_hash.as_deref().map(|h| format!("payment hash: {h}"));
-                let description = format_description(label, "Received", tx.amount_sats, rate_cents_per_btc, hash_suffix.as_deref());
+                let label = if tx.address.is_empty() {
+                    ""
+                } else if tx.label.is_empty() {
+                    &tx.address
+                } else {
+                    &tx.label
+                };
+                let hash_suffix = tx
+                    .payment_hash
+                    .as_deref()
+                    .map(|h| format!("payment hash: {h}"));
+                let description = format_description(
+                    label,
+                    "Received",
+                    tx.amount_sats,
+                    rate_cents_per_btc,
+                    hash_suffix.as_deref(),
+                );
 
                 entries.push(Entry {
                     entry_ref,
@@ -215,37 +238,54 @@ pub fn build_statement(
                         is_fee: true,
                     });
                 } else {
-
-                let label = if tx.address.is_empty() { "" } else if tx.label.is_empty() { &tx.address } else { &tx.label };
-                let verb = "Sent";
-                // For sub-cent fees, fold the fee mention into the description so
-                // the description reads "... BTC @ rate + N sat fee payment hash: ..." with no
-                // separate fee entry in the XML output.
-                let fee_note_str = tx.fee_sats
-                    .filter(|&f| {
-                        let abs_fee = f.unsigned_abs() as i64;
-                        abs_fee > 0 && convert_to_cents(abs_fee, rate_cents_per_btc) < config.fee_threshold_cents
-                    })
-                    .map(|f| {
-                        let abs_fee = f.unsigned_abs() as i64;
-                        match tx.payment_hash.as_deref() {
-                            Some(h) => format!("+ {abs_fee} sat fee payment hash: {h}"),
-                            None => format!("+ {abs_fee} sat fee"),
-                        }
+                    let label = if tx.address.is_empty() {
+                        ""
+                    } else if tx.label.is_empty() {
+                        &tx.address
+                    } else {
+                        &tx.label
+                    };
+                    let verb = "Sent";
+                    // For sub-cent fees, fold the fee mention into the description so
+                    // the description reads "... BTC @ rate + N sat fee payment hash: ..." with no
+                    // separate fee entry in the XML output.
+                    let fee_note_str = tx
+                        .fee_sats
+                        .filter(|&f| {
+                            let abs_fee = f.unsigned_abs() as i64;
+                            abs_fee > 0
+                                && convert_to_cents(abs_fee, rate_cents_per_btc)
+                                    < config.fee_threshold_cents
+                        })
+                        .map(|f| {
+                            let abs_fee = f.unsigned_abs() as i64;
+                            match tx.payment_hash.as_deref() {
+                                Some(h) => format!("+ {abs_fee} sat fee payment hash: {h}"),
+                                None => format!("+ {abs_fee} sat fee"),
+                            }
+                        });
+                    let effective_suffix = fee_note_str.or_else(|| {
+                        tx.payment_hash
+                            .as_deref()
+                            .map(|h| format!("payment hash: {h}"))
                     });
-                let effective_suffix = fee_note_str.or_else(|| tx.payment_hash.as_deref().map(|h| format!("payment hash: {h}")));
-                let description = format_description(label, verb, abs_sats, rate_cents_per_btc, effective_suffix.as_deref());
+                    let description = format_description(
+                        label,
+                        verb,
+                        abs_sats,
+                        rate_cents_per_btc,
+                        effective_suffix.as_deref(),
+                    );
 
-                entries.push(Entry {
-                    entry_ref,
-                    full_ref,
-                    booking_date: booking_date.clone(),
-                    amount_cents,
-                    is_credit: false,
-                    description,
-                    is_fee: false,
-                });
-
+                    entries.push(Entry {
+                        entry_ref,
+                        full_ref,
+                        booking_date: booking_date.clone(),
+                        amount_cents,
+                        is_credit: false,
+                        description,
+                        is_fee: false,
+                    });
                 } // else (not LiquidityPurchase)
 
                 // FIFO: consume lots and emit realized gain/loss
@@ -253,15 +293,15 @@ pub fn build_statement(
                     let mut remaining = abs_sats;
                     let mut total_cost = 0i64;
                     while remaining > 0 {
-                        let lot = lots.front_mut()
+                        let lot = lots
+                            .front_mut()
                             .context("FIFO: no lots available to cover send")?;
                         let consume = remaining.min(lot.remaining_sats);
                         // Proportional cost basis for the consumed portion
                         let lot_cost = if consume == lot.remaining_sats {
                             lot.cost_cents
                         } else {
-                            (lot.cost_cents as f64 * consume as f64
-                                / lot.remaining_sats as f64)
+                            (lot.cost_cents as f64 * consume as f64 / lot.remaining_sats as f64)
                                 .round() as i64
                         };
                         total_cost += lot_cost;
@@ -280,18 +320,24 @@ pub fn build_statement(
                         } else {
                             (false, -gain)
                         };
-                        let gain_ref = format!(":fifo:{}:{}:{}", tx.block_height,
-                            &tx.txid[..20.min(tx.txid.len())], tx.vout);
+                        let gain_ref = format!(
+                            ":fifo:{}:{}:{}",
+                            tx.block_height,
+                            &tx.txid[..20.min(tx.txid.len())],
+                            tx.vout
+                        );
                         entries.push(Entry {
                             entry_ref: gain_ref.clone(),
                             full_ref: gain_ref,
                             booking_date: booking_date.clone(),
                             amount_cents: gain_cents,
                             is_credit,
-                            description: format!("FIFO realized {} {}{:.2}",
+                            description: format!(
+                                "FIFO realized {} {}{:.2}",
                                 if is_credit { "gain" } else { "loss" },
                                 &config.currency,
-                                gain_cents as f64 / 100.0),
+                                gain_cents as f64 / 100.0
+                            ),
                             is_fee: false,
                         });
                         // Adjust balance_cents: the send was booked at spot, but
@@ -321,14 +367,14 @@ pub fn build_statement(
                     let mut remaining = abs_fee;
                     let mut total_cost = 0i64;
                     while remaining > 0 {
-                        let lot = lots.front_mut()
+                        let lot = lots
+                            .front_mut()
                             .context("FIFO: no lots available to cover fee")?;
                         let consume = remaining.min(lot.remaining_sats);
                         let lot_cost = if consume == lot.remaining_sats {
                             lot.cost_cents
                         } else {
-                            (lot.cost_cents as f64 * consume as f64
-                                / lot.remaining_sats as f64)
+                            (lot.cost_cents as f64 * consume as f64 / lot.remaining_sats as f64)
                                 .round() as i64
                         };
                         total_cost += lot_cost;
@@ -348,7 +394,11 @@ pub fn build_statement(
 
                 if fee_cents >= config.fee_threshold_cents {
                     entries.push(Entry {
-                        entry_ref: format!(":{}:{}:fee", tx.block_height, &tx.txid[..20.min(tx.txid.len())]),
+                        entry_ref: format!(
+                            ":{}:{}:fee",
+                            tx.block_height,
+                            &tx.txid[..20.min(tx.txid.len())]
+                        ),
                         full_ref: format!(":{}:{}:fee", tx.block_hash, tx.txid),
                         booking_date,
                         amount_cents: fee_cents,
@@ -368,7 +418,9 @@ pub fn build_statement(
     if config.mark_to_market && config.fiat_mode {
         let last_entry_year = entries
             .last()
-            .and_then(|e| NaiveDate::parse_from_str(booking_date_to_date(&e.booking_date), "%Y-%m-%d").ok())
+            .and_then(|e| {
+                NaiveDate::parse_from_str(booking_date_to_date(&e.booking_date), "%Y-%m-%d").ok()
+            })
             .map(|d| d.year());
 
         if let Some(year) = last_entry_year {
@@ -401,7 +453,9 @@ pub fn build_statement(
                  post-start transactions gives {} sats, \
                  but getbalance reports {} sats \
                  (difference: {} sats, post-start fees: {} sats)",
-                opening_sats, balance_sats, wallet_sats,
+                opening_sats,
+                balance_sats,
+                wallet_sats,
                 balance_sats - wallet_sats,
                 total_post_start_fees,
             );
@@ -412,9 +466,14 @@ pub fn build_statement(
         }
     }
 
-    let opening_date = config.start_date
+    let opening_date = config
+        .start_date
         .map(|d| d.format("%Y-%m-%d").to_string())
-        .or_else(|| entries.first().map(|e| booking_date_to_date(&e.booking_date).to_owned()))
+        .or_else(|| {
+            entries
+                .first()
+                .map(|e| booking_date_to_date(&e.booking_date).to_owned())
+        })
         .unwrap_or_else(|| "1970-01-01".to_owned());
 
     let statement_date = entries
@@ -468,7 +527,8 @@ fn mark_to_market_entry(
     // CET is UTC+1
     let year_end_utc = year_end_midnight_cet.and_utc().timestamp() - 3600;
 
-    let rate = provider.get_vwap(year_end_utc, interval_minutes)
+    let rate = provider
+        .get_vwap(year_end_utc, interval_minutes)
         .with_context(|| format!("failed to get year-end rate for {year}"))?;
 
     let target_cents = sats_to_cents(balance_sats, rate);
@@ -517,9 +577,19 @@ fn format_full_ref(block_hash: &str, txid: &str, vout: u32) -> String {
     format!("{block_hash}:{txid}:{vout}")
 }
 
-fn format_description(label: &str, verb: &str, sats: i64, rate_cents_per_btc: Option<f64>, suffix: Option<&str>) -> String {
+fn format_description(
+    label: &str,
+    verb: &str,
+    sats: i64,
+    rate_cents_per_btc: Option<f64>,
+    suffix: Option<&str>,
+) -> String {
     let btc = sats as f64 / 100_000_000.0;
-    let prefix = if label.is_empty() { String::new() } else { format!("{label} - ") };
+    let prefix = if label.is_empty() {
+        String::new()
+    } else {
+        format!("{label} - ")
+    };
     let rate_part = match rate_cents_per_btc {
         Some(rate) => format!(" @ {rate:.2}"),
         None => String::new(),
@@ -687,10 +757,7 @@ mod tests {
     #[test]
     fn entry_ref_format() {
         let txid = "aabbccddee11223344556677889900aabbccddee11223344556677889900aabb";
-        assert_eq!(
-            format_entry_ref(100, txid, 0),
-            "100:aabbccddee1122334455:0"
-        );
+        assert_eq!(format_entry_ref(100, txid, 0), "100:aabbccddee1122334455:0");
     }
 
     /// When all BTC is sold before year-end, balance_sats is 0 but balance_cents
@@ -744,8 +811,14 @@ mod tests {
         // balance_cents = 450_000 - 475_000 = -25_000
         // MTM target = 0 sats at 95k = 0 cents
         // adjustment = 0 - (-25_000) = 25_000 (credit)
-        let mtm = stmt.entries.iter().find(|e| e.entry_ref.starts_with(":mtm:"));
-        assert!(mtm.is_some(), "MTM entry should be generated even with zero BTC balance");
+        let mtm = stmt
+            .entries
+            .iter()
+            .find(|e| e.entry_ref.starts_with(":mtm:"));
+        assert!(
+            mtm.is_some(),
+            "MTM entry should be generated even with zero BTC balance"
+        );
         let mtm = mtm.unwrap();
         assert_eq!(mtm.amount_cents, 25_000);
         assert!(mtm.is_credit);
@@ -766,14 +839,11 @@ mod tests {
             }
         }
 
-        let txs = vec![
-            make_receive(5_000_000, 1_736_899_200, 100),
-            {
-                let mut tx = make_send(5_000_000, 0, 1_742_025_600, 101);
-                tx.txid = "ee".repeat(32);
-                tx
-            },
-        ];
+        let txs = vec![make_receive(5_000_000, 1_736_899_200, 100), {
+            let mut tx = make_send(5_000_000, 0, 1_742_025_600, 101);
+            tx.txid = "ee".repeat(32);
+            tx
+        }];
 
         let config = AccountingConfig {
             fiat_mode: true,
@@ -796,7 +866,10 @@ mod tests {
         // Receive: 5_000_000 * 90_000 * 100 / 100_000_000 = 450_000 cents
         // Send:    5_000_000 * 95_000 * 100 / 100_000_000 = 475_000 cents
         // FIFO gain: 475_000 - 450_000 = 25_000 cents (credit)
-        let fifo = stmt.entries.iter().find(|e| e.entry_ref.starts_with(":fifo:"));
+        let fifo = stmt
+            .entries
+            .iter()
+            .find(|e| e.entry_ref.starts_with(":fifo:"));
         assert!(fifo.is_some(), "FIFO entry should be generated");
         let fifo = fifo.unwrap();
         assert_eq!(fifo.amount_cents, 25_000);
@@ -806,8 +879,14 @@ mod tests {
         // With FIFO, balance_cents should be 0 after selling all at a gain,
         // because the gain entry corrected balance_cents.
         // MTM should then be 0 (no adjustment needed).
-        let mtm = stmt.entries.iter().find(|e| e.entry_ref.starts_with(":mtm:"));
-        assert!(mtm.is_none(), "MTM should not fire when FIFO already zeroed the balance");
+        let mtm = stmt
+            .entries
+            .iter()
+            .find(|e| e.entry_ref.starts_with(":mtm:"));
+        assert!(
+            mtm.is_none(),
+            "MTM should not fire when FIFO already zeroed the balance"
+        );
         assert_eq!(stmt.closing_balance_cents, 0);
     }
 
@@ -825,14 +904,11 @@ mod tests {
             }
         }
 
-        let txs = vec![
-            make_receive(10_000_000, 1_736_899_200, 100),
-            {
-                let mut tx = make_send(4_000_000, 0, 1_742_025_600, 101);
-                tx.txid = "ee".repeat(32);
-                tx
-            },
-        ];
+        let txs = vec![make_receive(10_000_000, 1_736_899_200, 100), {
+            let mut tx = make_send(4_000_000, 0, 1_742_025_600, 101);
+            tx.txid = "ee".repeat(32);
+            tx
+        }];
 
         let config = AccountingConfig {
             fiat_mode: true,
@@ -856,7 +932,11 @@ mod tests {
         // Send:    4_000_000 * 95_000 / 1e8 * 100 = 380_000 cents (spot)
         // Cost basis of 4M sats from lot: 900_000 * 4/10 = 360_000
         // FIFO gain: 380_000 - 360_000 = 20_000
-        let fifo = stmt.entries.iter().find(|e| e.entry_ref.starts_with(":fifo:")).unwrap();
+        let fifo = stmt
+            .entries
+            .iter()
+            .find(|e| e.entry_ref.starts_with(":fifo:"))
+            .unwrap();
         assert_eq!(fifo.amount_cents, 20_000);
         assert!(fifo.is_credit);
 
@@ -864,7 +944,11 @@ mod tests {
         // balance_cents after send+fifo = 900_000 - 380_000 + 20_000 = 540_000
         // MTM: 6_000_000 * 95_000 / 1e8 * 100 = 570_000 target
         // adjustment = 570_000 - 540_000 = 30_000 (credit)
-        let mtm = stmt.entries.iter().find(|e| e.entry_ref.starts_with(":mtm:")).unwrap();
+        let mtm = stmt
+            .entries
+            .iter()
+            .find(|e| e.entry_ref.starts_with(":mtm:"))
+            .unwrap();
         assert_eq!(mtm.amount_cents, 30_000);
         assert!(mtm.is_credit);
         assert_eq!(stmt.closing_balance_cents, 570_000);
@@ -887,17 +971,20 @@ mod tests {
         }
 
         let txs = vec![
-            { // receive 0.03 BTC at 90k
+            {
+                // receive 0.03 BTC at 90k
                 let mut tx = make_receive(3_000_000, 1_736_500_000, 100);
                 tx.txid = "a1".repeat(32);
                 tx
             },
-            { // receive 0.02 BTC at 100k
+            {
+                // receive 0.02 BTC at 100k
                 let mut tx = make_receive(2_000_000, 1_737_500_000, 101);
                 tx.txid = "a2".repeat(32);
                 tx
             },
-            { // send 0.04 BTC at 95k — consumes all of lot 1 + part of lot 2
+            {
+                // send 0.04 BTC at 95k — consumes all of lot 1 + part of lot 2
                 let mut tx = make_send(4_000_000, 0, 1_742_025_600, 102);
                 tx.txid = "ee".repeat(32);
                 tx
@@ -928,7 +1015,11 @@ mod tests {
         // Consumed: all of lot 1 (270_000) + 1_000_000 from lot 2 (cost = 200_000 * 1/2 = 100_000)
         // Total cost = 270_000 + 100_000 = 370_000
         // FIFO gain = 380_000 - 370_000 = 10_000
-        let fifo = stmt.entries.iter().find(|e| e.entry_ref.starts_with(":fifo:")).unwrap();
+        let fifo = stmt
+            .entries
+            .iter()
+            .find(|e| e.entry_ref.starts_with(":fifo:"))
+            .unwrap();
         assert_eq!(fifo.amount_cents, 10_000);
         assert!(fifo.is_credit);
 
@@ -936,7 +1027,11 @@ mod tests {
         // balance_cents = 270_000 + 200_000 - 380_000 + 10_000 = 100_000
         // MTM target = 1_000_000 * 95_000 / 1e8 * 100 = 95_000
         // adjustment = 95_000 - 100_000 = -5_000 (debit/loss)
-        let mtm = stmt.entries.iter().find(|e| e.entry_ref.starts_with(":mtm:")).unwrap();
+        let mtm = stmt
+            .entries
+            .iter()
+            .find(|e| e.entry_ref.starts_with(":mtm:"))
+            .unwrap();
         assert_eq!(mtm.amount_cents, 5_000);
         assert!(!mtm.is_credit); // loss
         assert_eq!(stmt.closing_balance_cents, 95_000);

--- a/src/commands/cache_rates.rs
+++ b/src/commands/cache_rates.rs
@@ -122,8 +122,7 @@ pub fn run(args: CacheRatesArgs) -> Result<()> {
     let now = Utc::now();
     let (start_ts, end_ts) = closed_interval_year_bounds(args.year, now, target_interval_minutes)?;
 
-    let mut missing_starts =
-        expected_interval_starts(start_ts, end_ts, target_interval_minutes);
+    let mut missing_starts = expected_interval_starts(start_ts, end_ts, target_interval_minutes);
     let mut cache = load_disk_cache();
     let existing_cache_count = count_cached_starts(
         &missing_starts,
@@ -140,7 +139,8 @@ pub fn run(args: CacheRatesArgs) -> Result<()> {
         );
     }
     let full_span_quarters = missing_quarters(&missing_starts);
-    let quarterly_files = if !missing_starts.is_empty() && args.year >= QUARTERLY_ARCHIVE_FIRST_YEAR {
+    let quarterly_files = if !missing_starts.is_empty() && args.year >= QUARTERLY_ARCHIVE_FIRST_YEAR
+    {
         let archive_client = build_http_client("Kraken archive", None)?;
         eprintln!(
             "Fetching Kraken {} archive listing for {}...",
@@ -178,15 +178,10 @@ pub fn run(args: CacheRatesArgs) -> Result<()> {
         let kraken_client = build_http_client("clearnet Kraken", None)?;
         eprintln!(
             "Fetching Kraken OHLC API rows at {}-minute resolution for {}...",
-            target_interval_minutes,
-            args.year,
+            target_interval_minutes, args.year,
         );
-        let candles = fetch_candles_since(
-            &kraken_client,
-            &config,
-            target_interval_minutes,
-            start_ts,
-        )?;
+        let candles =
+            fetch_candles_since(&kraken_client, &config, target_interval_minutes, start_ts)?;
 
         for candle in candles {
             if candle.time < start_ts || candle.time >= end_ts {
@@ -215,16 +210,14 @@ pub fn run(args: CacheRatesArgs) -> Result<()> {
         let archive_client = build_http_client("Kraken archive", None)?;
 
         let needed_quarters = missing_quarters(&missing_starts);
-        let quarterly_backfill_files = quarterly_files
-            .as_ref()
-            .and_then(|files| {
-                resolve_quarterly_archive_files(
-                    files,
-                    archive_mode.quarterly_archive_prefix(),
-                    args.year,
-                    &needed_quarters,
-                )
-            });
+        let quarterly_backfill_files = quarterly_files.as_ref().and_then(|files| {
+            resolve_quarterly_archive_files(
+                files,
+                archive_mode.quarterly_archive_prefix(),
+                args.year,
+                &needed_quarters,
+            )
+        });
 
         if let Some(files) = quarterly_backfill_files {
             for file in files {
@@ -293,9 +286,7 @@ pub fn run(args: CacheRatesArgs) -> Result<()> {
             let missing_before = missing_starts.len();
             eprintln!(
                 "Warning: exact {}-minute trade VWAP was unavailable for {} interval(s); falling back to {}-minute trade VWAP for those gaps.",
-                target_interval_minutes,
-                missing_before,
-                fallback_interval_minutes,
+                target_interval_minutes, missing_before, fallback_interval_minutes,
             );
             let mut level_stats = CacheWriteStats::default();
             for prepared_archive in &prepared_archives {
@@ -363,16 +354,18 @@ pub fn run(args: CacheRatesArgs) -> Result<()> {
     eprintln!("Replaced existing cache entries: {replaced_count}");
     eprintln!("Skipped existing cache entries: {skipped_count}");
     eprintln!("Kraken OHLC API rows: {}", recent_stats.written());
-    eprintln!("{}: {}", archive_mode.summary_label(), archive_stats.written());
+    eprintln!(
+        "{}: {}",
+        archive_mode.summary_label(),
+        archive_stats.written()
+    );
     if fallback_stats.written() > 0 {
         eprintln!(
             "Trade archive larger-candle fallback rows: {}",
             fallback_stats.written()
         );
     }
-    if used_complete_archive_fallback
-        && (archive_stats.total() > 0 || fallback_stats.total() > 0)
-    {
+    if used_complete_archive_fallback && (archive_stats.total() > 0 || fallback_stats.total() > 0) {
         eprintln!(
             "Quarterly {} archives were unavailable for {}, so the command fell back to the complete {} archive.",
             archive_mode.archive_label(),
@@ -457,10 +450,10 @@ fn closed_interval_year_bounds(
     now: chrono::DateTime<Utc>,
     interval_minutes: u32,
 ) -> Result<(i64, i64)> {
-    let year_start = NaiveDate::from_ymd_opt(year, 1, 1)
-        .ok_or_else(|| anyhow!("invalid year: {year}"))?;
-    let next_year_start = NaiveDate::from_ymd_opt(year + 1, 1, 1)
-        .ok_or_else(|| anyhow!("invalid year: {year}"))?;
+    let year_start =
+        NaiveDate::from_ymd_opt(year, 1, 1).ok_or_else(|| anyhow!("invalid year: {year}"))?;
+    let next_year_start =
+        NaiveDate::from_ymd_opt(year + 1, 1, 1).ok_or_else(|| anyhow!("invalid year: {year}"))?;
     let year_start_ts = midnight_utc_timestamp(year_start);
     let next_year_start_ts = midnight_utc_timestamp(next_year_start);
     let interval_seconds = i64::from(interval_minutes) * 60;
@@ -522,9 +515,8 @@ fn drop_cached_starts(
     kraken_pair: &str,
     interval_minutes: u32,
 ) {
-    missing_starts.retain(|start| {
-        !cache.contains_key(&cache_key(kraken_pair, interval_minutes, *start))
-    });
+    missing_starts
+        .retain(|start| !cache.contains_key(&cache_key(kraken_pair, interval_minutes, *start)));
 }
 
 fn store_cache_value(
@@ -712,9 +704,8 @@ fn ensure_archive_entry_extracted(
 
     let archive_file = File::open(archive_path)
         .with_context(|| format!("failed to open archive {}", archive_path.display()))?;
-    let mut archive = ZipArchive::new(archive_file).with_context(|| {
-        format!("failed to read ZIP archive {}", archive_path.display())
-    })?;
+    let mut archive = ZipArchive::new(archive_file)
+        .with_context(|| format!("failed to read ZIP archive {}", archive_path.display()))?;
     let entry_name = resolve_archive_entry_name(&mut archive, &expected_entry_name)?;
     eprintln!(
         "Extracting {} from {} into {}...",
@@ -733,12 +724,19 @@ fn ensure_archive_entry_extracted(
         .with_context(|| format!("failed to create {}", temp_path.display()))?;
     io::copy(&mut csv_file, &mut output)
         .with_context(|| format!("failed to write {}", temp_path.display()))?;
-    fs::rename(&temp_path, &extracted_path)
-        .with_context(|| format!("failed to move extracted data into {}", extracted_path.display()))?;
+    fs::rename(&temp_path, &extracted_path).with_context(|| {
+        format!(
+            "failed to move extracted data into {}",
+            extracted_path.display()
+        )
+    })?;
     Ok(extracted_path)
 }
 
-fn extracted_csv_timestamp_bounds(path: &Path, entry_name: &str) -> Result<Option<ArchiveCoverage>> {
+fn extracted_csv_timestamp_bounds(
+    path: &Path,
+    entry_name: &str,
+) -> Result<Option<ArchiveCoverage>> {
     let csv_file = File::open(path)
         .with_context(|| format!("failed to open extracted archive data {}", path.display()))?;
     let mut reader = csv::ReaderBuilder::new()
@@ -1003,7 +1001,11 @@ fn extract_quarterly_drive_files(
         let name_end = blob[name_start..]
             .find(".zip")
             .map(|idx| name_start + idx + 4)
-            .ok_or_else(|| anyhow!("failed to parse a quarterly {archive_label} archive filename from Google Drive"))?;
+            .ok_or_else(|| {
+                anyhow!(
+                    "failed to parse a quarterly {archive_label} archive filename from Google Drive"
+                )
+            })?;
         let name = blob[name_start..name_end].to_owned();
 
         let suffix = &blob[name_end..];
@@ -1087,7 +1089,9 @@ fn download_google_drive_file(client: &Client, file_id: &str, destination: &Path
                 ("uuid", uuid),
             ])
             .send()
-            .with_context(|| format!("failed to confirm the Google Drive download for {file_id}"))?;
+            .with_context(|| {
+                format!("failed to confirm the Google Drive download for {file_id}")
+            })?;
 
         write_response_to_file(confirmed, destination)
     } else {
@@ -1107,8 +1111,12 @@ fn ensure_archive_downloaded(
     let mut existing_coverage = None;
     if destination.exists() {
         if file.name == archive_mode.complete_archive_name() {
-            let extracted_path =
-                ensure_archive_entry_extracted(destination, &file.name, archive_pair, archive_mode)?;
+            let extracted_path = ensure_archive_entry_extracted(
+                destination,
+                &file.name,
+                archive_pair,
+                archive_mode,
+            )?;
             let coverage = inspect_archive_coverage(
                 &extracted_path,
                 &format!("cached extracted {archive_pair} data"),
@@ -1212,7 +1220,9 @@ fn ensure_archive_downloaded(
             "Saved {} to {}{}.",
             archive_file_description(file, archive_mode),
             destination.display(),
-            archive_file_size_label(destination).as_deref().unwrap_or(""),
+            archive_file_size_label(destination)
+                .as_deref()
+                .unwrap_or(""),
         );
         let extracted_path =
             ensure_archive_entry_extracted(destination, &file.name, archive_pair, archive_mode)?;
@@ -1236,8 +1246,8 @@ fn inspect_archive_coverage(
     target_interval_minutes: u32,
 ) -> Result<ArchiveCoverage> {
     eprintln!("Scanning coverage from {} at {}...", label, path.display());
-    let coverage = extracted_csv_timestamp_bounds(path, label)?
-        .context("archive pair CSV is empty")?;
+    let coverage =
+        extracted_csv_timestamp_bounds(path, label)?.context("archive pair CSV is empty")?;
     eprintln!(
         "{} appears to cover {} through {}.",
         label,
@@ -1253,8 +1263,7 @@ fn accept_complete_archive_replacement(
 ) -> bool {
     match existing_coverage {
         Some(existing) => {
-            downloaded_coverage.first <= existing.first
-                && downloaded_coverage.last >= existing.last
+            downloaded_coverage.first <= existing.first && downloaded_coverage.last >= existing.last
         }
         None => true,
     }
@@ -1278,7 +1287,11 @@ fn archive_file_description(file: &DriveFile, archive_mode: ArchiveBackfillMode)
             archive_mode.archive_label()
         )
     } else {
-        format!("Kraken {} archive {}", archive_mode.archive_label(), file.name)
+        format!(
+            "Kraken {} archive {}",
+            archive_mode.archive_label(),
+            file.name
+        )
     }
 }
 
@@ -1568,13 +1581,12 @@ mod tests {
     use crate::common::AppConfig;
 
     use super::{
-        ArchiveCoverage, CacheRatesArgs, CacheWriteOutcome, DriveFile,
-        accept_complete_archive_replacement,
-        PreparedArchive, archive_download_path, archive_pair_name, ensure_archive_downloaded,
-        extracted_archive_entry_path, extract_quarterly_drive_files, parse_args_from,
-        read_ohlcvt_daily_csv, read_trade_interval_csv, resolve_archive_entry_name,
-        resolve_quarterly_archive_files, should_store_api_candle, store_cache_value,
-        target_interval_minutes,
+        ArchiveCoverage, CacheRatesArgs, CacheWriteOutcome, DriveFile, PreparedArchive,
+        accept_complete_archive_replacement, archive_download_path, archive_pair_name,
+        ensure_archive_downloaded, extract_quarterly_drive_files, extracted_archive_entry_path,
+        parse_args_from, read_ohlcvt_daily_csv, read_trade_interval_csv,
+        resolve_archive_entry_name, resolve_quarterly_archive_files, should_store_api_candle,
+        store_cache_value, target_interval_minutes,
     };
 
     const REAL_XBTEUR_1440_SAMPLE: &str = "\
@@ -1661,9 +1673,10 @@ mod tests {
         )
         .expect_err("should fail");
 
-        assert!(err
-            .to_string()
-            .contains("usage: btc_fiat_value cache-rates [--vwap] [--candle <minutes>] <year>"));
+        assert!(
+            err.to_string()
+                .contains("usage: btc_fiat_value cache-rates [--vwap] [--candle <minutes>] <year>")
+        );
     }
 
     #[test]
@@ -1796,8 +1809,7 @@ mod tests {
             "';if (window['_DRIVE_ivdc'])"
         );
 
-        let files = extract_quarterly_drive_files(html, "Kraken_OHLCVT_", "OHLCVT")
-            .expect("files");
+        let files = extract_quarterly_drive_files(html, "Kraken_OHLCVT_", "OHLCVT").expect("files");
         assert_eq!(files["Kraken_OHLCVT_Q1_2024.zip"].id, "abc123");
         assert_eq!(files["Kraken_OHLCVT_Q2_2024.zip"].id, "def456");
     }
@@ -1813,8 +1825,8 @@ mod tests {
             "';if (window['_DRIVE_ivdc'])"
         );
 
-        let files = extract_quarterly_drive_files(html, "Kraken_Trading_History_", "trade")
-            .expect("files");
+        let files =
+            extract_quarterly_drive_files(html, "Kraken_Trading_History_", "trade").expect("files");
         assert_eq!(files["Kraken_Trading_History_Q1_2024.zip"].id, "abc123");
         assert_eq!(files["Kraken_Trading_History_Q2_2024.zip"].id, "def456");
     }
@@ -1876,15 +1888,15 @@ mod tests {
 
     #[test]
     fn archive_ohlc_matches_live_overlap_day_fields() {
-        let record = csv::StringRecord::from(
-            REAL_XBTEUR_1440_OVERLAP_ROW
-                .split(',')
-                .collect::<Vec<_>>(),
-        );
+        let record =
+            csv::StringRecord::from(REAL_XBTEUR_1440_OVERLAP_ROW.split(',').collect::<Vec<_>>());
 
         // Sanity check against the live Kraken 1440 OHLC API on 2024-04-01 UTC:
         // the daily candle boundaries and OHLC fields match the archive row.
-        assert_eq!(super::parse_archive_timestamp(&record, "XBTEUR_1440.csv").unwrap(), 1711929600);
+        assert_eq!(
+            super::parse_archive_timestamp(&record, "XBTEUR_1440.csv").unwrap(),
+            1711929600
+        );
         assert_eq!(
             super::parse_archive_number(&record, 1, "open", "XBTEUR_1440.csv").unwrap(),
             66130.0
@@ -1923,14 +1935,19 @@ mod tests {
         )
         .expect_err("row should fail");
 
-        assert!(err.to_string().contains("XBTEUR_1440.csv row is missing the close column"));
+        assert!(
+            err.to_string()
+                .contains("XBTEUR_1440.csv row is missing the close column")
+        );
     }
 
     #[test]
     fn reports_invalid_close_price_clearly() {
         let mut reader = csv::ReaderBuilder::new()
             .has_headers(false)
-            .from_reader(Cursor::new("1672531200,15423.8,15524.8,15388.5,nope,532.29189029,11775\n"));
+            .from_reader(Cursor::new(
+                "1672531200,15423.8,15524.8,15388.5,nope,532.29189029,11775\n",
+            ));
         let mut missing_days = BTreeSet::from([1672531200_i64]);
         let mut cache = HashMap::new();
 
@@ -1946,9 +1963,10 @@ mod tests {
         )
         .expect_err("row should fail");
 
-        assert!(err
-            .to_string()
-            .contains("invalid close value nope in XBTEUR_1440.csv"));
+        assert!(
+            err.to_string()
+                .contains("invalid close value nope in XBTEUR_1440.csv")
+        );
     }
 
     #[test]
@@ -1980,8 +1998,14 @@ mod tests {
         assert_eq!(stats.inserted, 2);
         assert_eq!(stats.replaced, 0);
         assert_eq!(stats.skipped, 0);
-        assert_eq!(cache["XXBTZEUR:1440:1735689600"], super::normalize_fiat_rate(day1));
-        assert_eq!(cache["XXBTZEUR:1440:1735776000"], super::normalize_fiat_rate(day2));
+        assert_eq!(
+            cache["XXBTZEUR:1440:1735689600"],
+            super::normalize_fiat_rate(day1)
+        );
+        assert_eq!(
+            cache["XXBTZEUR:1440:1735776000"],
+            super::normalize_fiat_rate(day2)
+        );
         assert!(missing_days.is_empty());
     }
 
@@ -2015,8 +2039,14 @@ mod tests {
         assert_eq!(stats.inserted, 2);
         assert_eq!(stats.replaced, 0);
         assert_eq!(stats.skipped, 0);
-        assert_eq!(cache["XXBTZEUR:60:1735689600"], super::normalize_fiat_rate(107.5));
-        assert_eq!(cache["XXBTZEUR:60:1735693200"], super::normalize_fiat_rate(105.0));
+        assert_eq!(
+            cache["XXBTZEUR:60:1735689600"],
+            super::normalize_fiat_rate(107.5)
+        );
+        assert_eq!(
+            cache["XXBTZEUR:60:1735693200"],
+            super::normalize_fiat_rate(105.0)
+        );
         assert!(missing_hours.is_empty());
     }
 
@@ -2029,8 +2059,12 @@ mod tests {
         let mut reader = csv::ReaderBuilder::new()
             .has_headers(false)
             .from_reader(Cursor::new(trades));
-        let mut missing_hours =
-            BTreeSet::from([1735689600_i64, 1735693200_i64, 1735696800_i64, 1735700400_i64]);
+        let mut missing_hours = BTreeSet::from([
+            1735689600_i64,
+            1735693200_i64,
+            1735696800_i64,
+            1735700400_i64,
+        ]);
         let mut cache = HashMap::new();
 
         let stats = read_trade_interval_csv(
@@ -2050,10 +2084,22 @@ mod tests {
         assert_eq!(stats.inserted, 4);
         assert_eq!(stats.replaced, 0);
         assert_eq!(stats.skipped, 0);
-        assert_eq!(cache["XXBTZEUR:60:1735689600"], super::normalize_fiat_rate(vwap));
-        assert_eq!(cache["XXBTZEUR:60:1735693200"], super::normalize_fiat_rate(vwap));
-        assert_eq!(cache["XXBTZEUR:60:1735696800"], super::normalize_fiat_rate(vwap));
-        assert_eq!(cache["XXBTZEUR:60:1735700400"], super::normalize_fiat_rate(vwap));
+        assert_eq!(
+            cache["XXBTZEUR:60:1735689600"],
+            super::normalize_fiat_rate(vwap)
+        );
+        assert_eq!(
+            cache["XXBTZEUR:60:1735693200"],
+            super::normalize_fiat_rate(vwap)
+        );
+        assert_eq!(
+            cache["XXBTZEUR:60:1735696800"],
+            super::normalize_fiat_rate(vwap)
+        );
+        assert_eq!(
+            cache["XXBTZEUR:60:1735700400"],
+            super::normalize_fiat_rate(vwap)
+        );
         assert!(missing_hours.is_empty());
     }
 
@@ -2086,8 +2132,14 @@ mod tests {
         assert_eq!(stats.inserted, 2);
         assert_eq!(stats.replaced, 0);
         assert_eq!(stats.skipped, 0);
-        assert_eq!(cache["XXBTZEUR:60:1735693200"], super::normalize_fiat_rate(vwap));
-        assert_eq!(cache["XXBTZEUR:60:1735696800"], super::normalize_fiat_rate(vwap));
+        assert_eq!(
+            cache["XXBTZEUR:60:1735693200"],
+            super::normalize_fiat_rate(vwap)
+        );
+        assert_eq!(
+            cache["XXBTZEUR:60:1735696800"],
+            super::normalize_fiat_rate(vwap)
+        );
         assert!(missing_hours.is_empty());
     }
 
@@ -2145,7 +2197,10 @@ mod tests {
         assert_eq!(stats.inserted, 0);
         assert_eq!(stats.replaced, 0);
         assert_eq!(stats.skipped, 1);
-        assert_eq!(cache["XXBTZEUR:1440:1735689600"], super::normalize_fiat_rate(day1));
+        assert_eq!(
+            cache["XXBTZEUR:1440:1735689600"],
+            super::normalize_fiat_rate(day1)
+        );
         assert!(missing_days.is_empty());
     }
 
@@ -2156,8 +2211,7 @@ mod tests {
             .from_reader(Cursor::new(REAL_XBTEUR_2026_03_21_TRADES));
         // 2026-03-21 02:00–04:59 UTC — three quiet hours from real Kraken trades.
         // API 60-min OHLC VWAPs for this window: 60995.3, 61074.2, 61145.7
-        let mut missing_hours =
-            BTreeSet::from([1774058400_i64, 1774062000_i64, 1774065600_i64]);
+        let mut missing_hours = BTreeSet::from([1774058400_i64, 1774062000_i64, 1774065600_i64]);
         let mut cache = HashMap::new();
 
         let stats = read_trade_interval_csv(
@@ -2176,9 +2230,18 @@ mod tests {
         assert_eq!(stats.inserted, 3);
         assert_eq!(stats.replaced, 0);
         assert_eq!(stats.skipped, 0);
-        assert_eq!(cache["XXBTZEUR:60:1774058400"], super::normalize_fiat_rate(60995.38));
-        assert_eq!(cache["XXBTZEUR:60:1774062000"], super::normalize_fiat_rate(61074.23));
-        assert_eq!(cache["XXBTZEUR:60:1774065600"], super::normalize_fiat_rate(61145.71));
+        assert_eq!(
+            cache["XXBTZEUR:60:1774058400"],
+            super::normalize_fiat_rate(60995.38)
+        );
+        assert_eq!(
+            cache["XXBTZEUR:60:1774062000"],
+            super::normalize_fiat_rate(61074.23)
+        );
+        assert_eq!(
+            cache["XXBTZEUR:60:1774065600"],
+            super::normalize_fiat_rate(61145.71)
+        );
         assert!(missing_hours.is_empty());
     }
 
@@ -2203,9 +2266,10 @@ mod tests {
         )
         .expect_err("row should fail");
 
-        assert!(err
-            .to_string()
-            .contains("XBTEUR.csv row is missing the volume column"));
+        assert!(
+            err.to_string()
+                .contains("XBTEUR.csv row is missing the volume column")
+        );
     }
 
     #[test]
@@ -2229,9 +2293,10 @@ mod tests {
         )
         .expect_err("row should fail");
 
-        assert!(err
-            .to_string()
-            .contains("invalid volume value nope in XBTEUR.csv"));
+        assert!(
+            err.to_string()
+                .contains("invalid volume value nope in XBTEUR.csv")
+        );
     }
 
     #[test]

--- a/src/commands/export.rs
+++ b/src/commands/export.rs
@@ -1,5 +1,5 @@
-use std::env;
 use std::collections::HashSet;
+use std::env;
 use std::fs::File;
 use std::io::BufWriter;
 use std::path::{Path, PathBuf};
@@ -9,15 +9,15 @@ use chrono::NaiveDate;
 
 use crate::accounting::{AccountingConfig, build_statement};
 use crate::common::{AppConfig, default_bitcoin_datadir};
-use crate::export::{Entry, Statement};
-use crate::export::booking_date_to_date;
-use crate::export::camt053::Camt053ParseResult;
 use crate::exchange_rate::KrakenProvider;
-use crate::export::camt053::Camt053Exporter;
 use crate::export::AccountingExporter;
+use crate::export::booking_date_to_date;
+use crate::export::camt053::Camt053Exporter;
+use crate::export::camt053::Camt053ParseResult;
+use crate::export::{Entry, Statement};
 use crate::iban::{iban_from_fingerprint, iban_from_node_id};
-use crate::import::WalletTransaction;
 use crate::import::TransactionSource;
+use crate::import::WalletTransaction;
 use crate::import::bitcoin_core_rpc::BitcoinCoreRpc;
 use crate::import::phoenixd_csv::PhoenixdCsv;
 
@@ -124,10 +124,18 @@ pub fn run(args: ExportArgs) -> Result<()> {
 
         // Consistency checks
         if parsed.account_iban != iban {
-            bail!("IBAN mismatch: file has {} but wallet fingerprint gives {}", parsed.account_iban, iban);
+            bail!(
+                "IBAN mismatch: file has {} but wallet fingerprint gives {}",
+                parsed.account_iban,
+                iban
+            );
         }
         if parsed.currency != currency {
-            bail!("currency mismatch: file has {} but current config uses {}", parsed.currency, currency);
+            bail!(
+                "currency mismatch: file has {} but current config uses {}",
+                parsed.currency,
+                currency
+            );
         }
 
         let plan = existing_export_plan_from_existing_export(args.start_date, parsed)?;
@@ -145,7 +153,11 @@ pub fn run(args: ExportArgs) -> Result<()> {
 
     if let Some(plan) = existing_plan.as_ref() {
         if !plan.existing_entry_refs.is_empty() {
-            transactions.retain(|tx| !plan.existing_entry_refs.contains(&transaction_entry_ref(tx)));
+            transactions.retain(|tx| {
+                !plan
+                    .existing_entry_refs
+                    .contains(&transaction_entry_ref(tx))
+            });
         }
         if let Some(end_exclusive) = plan.build_end_exclusive {
             let end_exclusive_ts = end_exclusive
@@ -206,17 +218,30 @@ pub fn run(args: ExportArgs) -> Result<()> {
     }
 
     // Count new entries (excluding those from the existing file)
-    let new_entries: Vec<_> = statement.entries.iter()
+    let new_entries: Vec<_> = statement
+        .entries
+        .iter()
         .filter(|e| !existing_entry_refs.contains(&e.entry_ref))
         .collect();
-    let new_tx_count = new_entries.iter().filter(|e| !e.is_fee && !e.entry_ref.starts_with(":")).count();
-    let new_mtm_count = new_entries.iter().filter(|e| e.entry_ref.starts_with(":mtm:")).count();
-    let new_fifo_count = new_entries.iter().filter(|e| e.entry_ref.starts_with(":fifo:")).count();
-    let first_date = new_entries.iter()
+    let new_tx_count = new_entries
+        .iter()
+        .filter(|e| !e.is_fee && !e.entry_ref.starts_with(":"))
+        .count();
+    let new_mtm_count = new_entries
+        .iter()
+        .filter(|e| e.entry_ref.starts_with(":mtm:"))
+        .count();
+    let new_fifo_count = new_entries
+        .iter()
+        .filter(|e| e.entry_ref.starts_with(":fifo:"))
+        .count();
+    let first_date = new_entries
+        .iter()
         .filter(|e| !e.is_fee && !e.entry_ref.starts_with(":"))
         .map(|e| e.booking_date.as_str())
         .next();
-    let last_date = new_entries.iter()
+    let last_date = new_entries
+        .iter()
         .filter(|e| !e.is_fee && !e.entry_ref.starts_with(":"))
         .map(|e| e.booking_date.as_str())
         .last();
@@ -252,13 +277,17 @@ pub fn run(args: ExportArgs) -> Result<()> {
             }
         }
     } else if new_mtm_count > 0 {
-        eprintln!("No new transactions; added {new_mtm_count} year-end mark-to-market entry/entries.");
+        eprintln!(
+            "No new transactions; added {new_mtm_count} year-end mark-to-market entry/entries."
+        );
     } else {
         eprintln!("No new transactions to export.");
     }
 
     if provider.cache_grew() {
-        eprintln!("Note: exchange rates cached in .cache/rates.json — delete when no longer needed for privacy.");
+        eprintln!(
+            "Note: exchange rates cached in .cache/rates.json — delete when no longer needed for privacy."
+        );
     }
 
     Ok(())
@@ -266,21 +295,32 @@ pub fn run(args: ExportArgs) -> Result<()> {
 
 /// Return type for the two source functions:
 /// (iban, transactions, wallet_balance_sats, descriptors, bank_name_default)
-type SourceResult = (String, Vec<WalletTransaction>, Option<i64>, Vec<String>, String);
+type SourceResult = (
+    String,
+    Vec<WalletTransaction>,
+    Option<i64>,
+    Vec<String>,
+    String,
+);
 
 fn run_bitcoin_core_source(args: &ExportArgs) -> Result<SourceResult> {
     let wallet = match &args.wallet {
         Some(w) => w.clone(),
         None => {
             let rpc_url = crate::import::bitcoin_core_rpc::rpc_url_for_chain(&args.chain)?;
-            let cookie_path = crate::import::bitcoin_core_rpc::cookie_path(&args.datadir, &args.chain);
-            let cookie = std::fs::read_to_string(&cookie_path)
-                .with_context(|| format!("failed to read cookie file at {}", cookie_path.display()))?;
+            let cookie_path =
+                crate::import::bitcoin_core_rpc::cookie_path(&args.datadir, &args.chain);
+            let cookie = std::fs::read_to_string(&cookie_path).with_context(|| {
+                format!("failed to read cookie file at {}", cookie_path.display())
+            })?;
             let wallets = BitcoinCoreRpc::list_wallets(&rpc_url, &cookie)?;
             match wallets.len() {
                 0 => bail!("no wallets loaded; specify --wallet"),
                 1 => wallets.into_iter().next().unwrap(),
-                n => bail!("{n} wallets loaded ({}) — specify --wallet", wallets.join(", ")),
+                n => bail!(
+                    "{n} wallets loaded ({}) — specify --wallet",
+                    wallets.join(", ")
+                ),
             }
         }
     };
@@ -293,7 +333,8 @@ fn run_bitcoin_core_source(args: &ExportArgs) -> Result<SourceResult> {
     let transactions = rpc.list_transactions()?;
     let wallet_balance_sats = Some(rpc.get_balance()?);
 
-    let receive_addresses: std::collections::HashSet<String> = transactions.iter()
+    let receive_addresses: std::collections::HashSet<String> = transactions
+        .iter()
         .filter(|tx| tx.category == crate::import::TxCategory::Receive)
         .map(|tx| tx.address.clone())
         .collect();
@@ -301,7 +342,13 @@ fn run_bitcoin_core_source(args: &ExportArgs) -> Result<SourceResult> {
 
     let bank_name_default = format!("Bitcoin Core - {wallet}");
 
-    Ok((iban, transactions, wallet_balance_sats, descriptors, bank_name_default))
+    Ok((
+        iban,
+        transactions,
+        wallet_balance_sats,
+        descriptors,
+        bank_name_default,
+    ))
 }
 
 fn phoenixd_node_cache_path() -> std::path::PathBuf {
@@ -339,7 +386,13 @@ fn run_phoenixd_source(csv_path: &Path, args: &ExportArgs) -> Result<SourceResul
 
     let bank_name_default = format!("Phoenixd - {node_id}");
 
-    Ok((iban, transactions, Some(wallet_balance_sats), vec![], bank_name_default))
+    Ok((
+        iban,
+        transactions,
+        Some(wallet_balance_sats),
+        vec![],
+        bank_name_default,
+    ))
 }
 
 fn quote_currency_from_pair(pair: &str) -> String {
@@ -350,7 +403,10 @@ fn quote_currency_from_pair(pair: &str) -> String {
     }
 }
 
-fn resolve_candle_minutes(candle_override_minutes: Option<u32>, default_candle_minutes: Option<u32>) -> u32 {
+fn resolve_candle_minutes(
+    candle_override_minutes: Option<u32>,
+    default_candle_minutes: Option<u32>,
+) -> u32 {
     candle_override_minutes
         .or(default_candle_minutes)
         .unwrap_or(1440)
@@ -410,9 +466,11 @@ fn existing_export_plan_from_existing_export(
 }
 
 fn parse_existing_opening_date(opening_date: Option<&str>) -> Result<NaiveDate> {
-    let opening_date = opening_date.context("existing CAMT.053 file is missing its opening balance date")?;
-    NaiveDate::parse_from_str(opening_date, "%Y-%m-%d")
-        .with_context(|| format!("invalid opening balance date in existing CAMT.053 file: {opening_date}"))
+    let opening_date =
+        opening_date.context("existing CAMT.053 file is missing its opening balance date")?;
+    NaiveDate::parse_from_str(opening_date, "%Y-%m-%d").with_context(|| {
+        format!("invalid opening balance date in existing CAMT.053 file: {opening_date}")
+    })
 }
 
 fn parse_last_booking_date(last_booking_date: Option<&str>) -> Result<Option<NaiveDate>> {
@@ -425,7 +483,12 @@ fn parse_last_booking_date(last_booking_date: Option<&str>) -> Result<Option<Nai
 }
 
 fn transaction_entry_ref(tx: &WalletTransaction) -> String {
-    format!("{}:{}:{}", tx.block_height, &tx.txid[..20.min(tx.txid.len())], tx.vout)
+    format!(
+        "{}:{}:{}",
+        tx.block_height,
+        &tx.txid[..20.min(tx.txid.len())],
+        tx.vout
+    )
 }
 
 fn merge_with_existing_statement(statement: &mut Statement, plan: ExistingExportPlan) {
@@ -451,7 +514,11 @@ fn merge_with_existing_statement(statement: &mut Statement, plan: ExistingExport
 }
 
 fn refresh_statement_totals(statement: &mut Statement) {
-    let net_entries = statement.entries.iter().map(signed_entry_amount).sum::<i64>();
+    let net_entries = statement
+        .entries
+        .iter()
+        .map(signed_entry_amount)
+        .sum::<i64>();
     statement.closing_balance_cents = statement.opening_balance_cents + net_entries;
     statement.statement_date = statement
         .entries
@@ -494,19 +561,32 @@ where
     while let Some(arg) = args.next() {
         match arg.as_str() {
             "--wallet" => {
-                wallet = Some(args.next().ok_or_else(|| anyhow::anyhow!("--wallet requires a value\n\n{usage}"))?);
+                wallet = Some(
+                    args.next()
+                        .ok_or_else(|| anyhow::anyhow!("--wallet requires a value\n\n{usage}"))?,
+                );
             }
             "--country" => {
-                country = Some(args.next().ok_or_else(|| anyhow::anyhow!("--country requires a value\n\n{usage}"))?);
+                country = Some(
+                    args.next()
+                        .ok_or_else(|| anyhow::anyhow!("--country requires a value\n\n{usage}"))?,
+                );
             }
             "--datadir" => {
-                datadir = Some(PathBuf::from(args.next().ok_or_else(|| anyhow::anyhow!("--datadir requires a value\n\n{usage}"))?));
+                datadir = Some(PathBuf::from(args.next().ok_or_else(|| {
+                    anyhow::anyhow!("--datadir requires a value\n\n{usage}")
+                })?));
             }
             "--chain" => {
-                chain = Some(args.next().ok_or_else(|| anyhow::anyhow!("--chain requires a value\n\n{usage}"))?);
+                chain = Some(
+                    args.next()
+                        .ok_or_else(|| anyhow::anyhow!("--chain requires a value\n\n{usage}"))?,
+                );
             }
             "--format" => {
-                let fmt = args.next().ok_or_else(|| anyhow::anyhow!("--format requires a value\n\n{usage}"))?;
+                let fmt = args
+                    .next()
+                    .ok_or_else(|| anyhow::anyhow!("--format requires a value\n\n{usage}"))?;
                 format = Some(match fmt.as_str() {
                     "camt053" => ExportFormat::Camt053,
                     _ => bail!("unsupported format: {fmt}\n\n{usage}"),
@@ -517,30 +597,53 @@ where
             "--no-mark-to-market" => mark_to_market = Some(false),
             "--fifo" => fifo = true,
             "--start-date" => {
-                let date_str = args.next().ok_or_else(|| anyhow::anyhow!("--start-date requires a value\n\n{usage}"))?;
-                start_date = Some(NaiveDate::parse_from_str(&date_str, "%Y-%m-%d")
-                    .with_context(|| format!("invalid date: {date_str}"))?);
+                let date_str = args
+                    .next()
+                    .ok_or_else(|| anyhow::anyhow!("--start-date requires a value\n\n{usage}"))?;
+                start_date = Some(
+                    NaiveDate::parse_from_str(&date_str, "%Y-%m-%d")
+                        .with_context(|| format!("invalid date: {date_str}"))?,
+                );
             }
             "--output" => {
-                output = Some(PathBuf::from(args.next().ok_or_else(|| anyhow::anyhow!("--output requires a value\n\n{usage}"))?));
+                output = Some(PathBuf::from(args.next().ok_or_else(|| {
+                    anyhow::anyhow!("--output requires a value\n\n{usage}")
+                })?));
             }
             "--candle" => {
-                let val = args.next().ok_or_else(|| anyhow::anyhow!("--candle requires a value\n\n{usage}"))?;
-                candle_minutes = Some(crate::common::parse_candle_interval_minutes(&val, "--candle")?);
+                let val = args
+                    .next()
+                    .ok_or_else(|| anyhow::anyhow!("--candle requires a value\n\n{usage}"))?;
+                candle_minutes = Some(crate::common::parse_candle_interval_minutes(
+                    &val, "--candle",
+                )?);
             }
             "--bank-name" => {
-                bank_name = Some(args.next().ok_or_else(|| anyhow::anyhow!("--bank-name requires a value\n\n{usage}"))?);
+                bank_name =
+                    Some(args.next().ok_or_else(|| {
+                        anyhow::anyhow!("--bank-name requires a value\n\n{usage}")
+                    })?);
             }
             "--phoenixd-csv" => {
-                phoenixd_csv = Some(PathBuf::from(args.next().ok_or_else(|| anyhow::anyhow!("--phoenixd-csv requires a value\n\n{usage}"))?));
+                phoenixd_csv = Some(PathBuf::from(args.next().ok_or_else(|| {
+                    anyhow::anyhow!("--phoenixd-csv requires a value\n\n{usage}")
+                })?));
             }
             "--nodeid" => {
-                node_id = Some(args.next().ok_or_else(|| anyhow::anyhow!("--nodeid requires a value\n\n{usage}"))?);
+                node_id = Some(
+                    args.next()
+                        .ok_or_else(|| anyhow::anyhow!("--nodeid requires a value\n\n{usage}"))?,
+                );
             }
             "--ignore-balance-mismatch" => ignore_balance_mismatch = true,
             "--fee-threshold-cents" => {
-                let val = args.next().ok_or_else(|| anyhow::anyhow!("--fee-threshold-cents requires a value\n\n{usage}"))?;
-                fee_threshold_cents = Some(val.parse::<i64>().with_context(|| format!("invalid --fee-threshold-cents: {val}"))?);
+                let val = args.next().ok_or_else(|| {
+                    anyhow::anyhow!("--fee-threshold-cents requires a value\n\n{usage}")
+                })?;
+                fee_threshold_cents = Some(
+                    val.parse::<i64>()
+                        .with_context(|| format!("invalid --fee-threshold-cents: {val}"))?,
+                );
             }
             "-h" | "--help" | "help" => bail!("{usage}"),
             _ => {
@@ -552,16 +655,25 @@ where
                         "--datadir" => datadir = Some(PathBuf::from(value)),
                         "--chain" => chain = Some(value.to_owned()),
                         "--output" => output = Some(PathBuf::from(value)),
-                        "--candle" => candle_minutes = Some(crate::common::parse_candle_interval_minutes(value, "--candle")?),
+                        "--candle" => {
+                            candle_minutes = Some(crate::common::parse_candle_interval_minutes(
+                                value, "--candle",
+                            )?)
+                        }
                         "--bank-name" => bank_name = Some(value.to_owned()),
                         "--phoenixd-csv" => phoenixd_csv = Some(PathBuf::from(value)),
                         "--nodeid" => node_id = Some(value.to_owned()),
                         "--fee-threshold-cents" => {
-                            fee_threshold_cents = Some(value.parse::<i64>().with_context(|| format!("invalid --fee-threshold-cents: {value}"))?);
+                            fee_threshold_cents =
+                                Some(value.parse::<i64>().with_context(|| {
+                                    format!("invalid --fee-threshold-cents: {value}")
+                                })?);
                         }
                         "--start-date" => {
-                            start_date = Some(NaiveDate::parse_from_str(value, "%Y-%m-%d")
-                                .with_context(|| format!("invalid date: {value}"))?);
+                            start_date = Some(
+                                NaiveDate::parse_from_str(value, "%Y-%m-%d")
+                                    .with_context(|| format!("invalid date: {value}"))?,
+                            );
                         }
                         "--format" => {
                             format = Some(match value {
@@ -578,8 +690,7 @@ where
         }
     }
 
-    let wallet = wallet
-        .or_else(|| env::var("BITCOIN_WALLET").ok());
+    let wallet = wallet.or_else(|| env::var("BITCOIN_WALLET").ok());
 
     let country = country
         .or_else(|| env::var("IBAN_COUNTRY").ok())
@@ -593,8 +704,7 @@ where
         .or_else(|| env::var("BITCOIN_DATADIR").ok().map(PathBuf::from))
         .unwrap_or_else(default_bitcoin_datadir);
 
-    let output = output
-        .ok_or_else(|| anyhow::anyhow!("--output is required\n\n{usage}"))?;
+    let output = output.ok_or_else(|| anyhow::anyhow!("--output is required\n\n{usage}"))?;
 
     let fiat_mode_env = env::var("FIAT_MODE")
         .ok()
@@ -819,7 +929,10 @@ mod tests {
         .expect_err("moving start date forward should fail");
 
         assert!(err.to_string().contains("already starts at 2025-01-01"));
-        assert!(err.to_string().contains("--start-date forward to 2025-06-01"));
+        assert!(
+            err.to_string()
+                .contains("--start-date forward to 2025-06-01")
+        );
     }
 
     #[test]

--- a/src/commands/export.rs
+++ b/src/commands/export.rs
@@ -18,6 +18,7 @@ use crate::export::{Entry, Statement};
 use crate::iban::{iban_from_fingerprint, iban_from_node_id};
 use crate::import::TransactionSource;
 use crate::import::WalletTransaction;
+use crate::import::bitcoin_core_bip329::BitcoinCoreBip329;
 use crate::import::bitcoin_core_rpc::BitcoinCoreRpc;
 use crate::import::phoenixd_csv::PhoenixdCsv;
 
@@ -40,6 +41,7 @@ options:
   --bank-name <name>    Bank/institution name (default: Bitcoin Core - <wallet>)
   --candle <minutes>    Kraken candle interval (default: DEFAULT_CANDLE_MINUTES or 1440)
   --fee-threshold-cents <n>  Fold fees below this threshold into the parent entry description (default: 1)
+  --bitcoin-core-bip329 <file>  Use a Bitcoin Core rich BIP329 JSONL export as the transaction source
   --phoenixd-csv <file>  Use a Phoenixd CSV export as the transaction source
   --nodeid <id>         Phoenixd node public key (from: phoenix-cli getinfo); cached in .cache/phoenixd_node.txt
   --ignore-balance-mismatch  Warn instead of error on forward/backward balance mismatch";
@@ -59,6 +61,7 @@ pub struct ExportArgs {
     pub candle_override_minutes: Option<u32>,
     pub bank_name: Option<String>,
     pub ignore_balance_mismatch: bool,
+    pub bitcoin_core_bip329: Option<PathBuf>,
     pub phoenixd_csv: Option<PathBuf>,
     pub node_id: Option<String>,
     pub fee_threshold_cents: Option<i64>,
@@ -89,7 +92,9 @@ enum ExistingMergeMode {
 
 pub fn run(args: ExportArgs) -> Result<()> {
     let (iban, mut transactions, wallet_balance_sats, descriptors, bank_name_default) =
-        if let Some(ref csv_path) = args.phoenixd_csv {
+        if let Some(ref bip329_path) = args.bitcoin_core_bip329 {
+            run_bitcoin_core_bip329_source(bip329_path, &args)?
+        } else if let Some(ref csv_path) = args.phoenixd_csv {
             run_phoenixd_source(csv_path, &args)?
         } else {
             run_bitcoin_core_source(&args)?
@@ -395,6 +400,22 @@ fn run_phoenixd_source(csv_path: &Path, args: &ExportArgs) -> Result<SourceResul
     ))
 }
 
+fn run_bitcoin_core_bip329_source(path: &Path, args: &ExportArgs) -> Result<SourceResult> {
+    let source = BitcoinCoreBip329::from_path(path)?;
+    let iban = iban_from_fingerprint(source.fingerprint(), &args.country, &args.chain)?;
+    eprintln!("Virtual IBAN: {iban}");
+
+    let transactions = source.list_transactions()?;
+    let descriptors = source.descriptors().to_vec();
+    let bank_name_default = path
+        .file_stem()
+        .and_then(|name| name.to_str())
+        .map(|name| format!("Bitcoin Core BIP329 - {name}"))
+        .unwrap_or_else(|| "Bitcoin Core BIP329".to_owned());
+
+    Ok((iban, transactions, None, descriptors, bank_name_default))
+}
+
 fn quote_currency_from_pair(pair: &str) -> String {
     if pair.len() >= 3 {
         pair[pair.len() - 3..].to_uppercase()
@@ -554,6 +575,7 @@ where
     let mut candle_minutes: Option<u32> = None;
     let mut bank_name: Option<String> = None;
     let mut ignore_balance_mismatch = false;
+    let mut bitcoin_core_bip329: Option<PathBuf> = None;
     let mut phoenixd_csv: Option<PathBuf> = None;
     let mut node_id: Option<String> = None;
     let mut fee_threshold_cents: Option<i64> = None;
@@ -629,6 +651,11 @@ where
                     anyhow::anyhow!("--phoenixd-csv requires a value\n\n{usage}")
                 })?));
             }
+            "--bitcoin-core-bip329" => {
+                bitcoin_core_bip329 = Some(PathBuf::from(args.next().ok_or_else(|| {
+                    anyhow::anyhow!("--bitcoin-core-bip329 requires a value\n\n{usage}")
+                })?));
+            }
             "--nodeid" => {
                 node_id = Some(
                     args.next()
@@ -662,6 +689,7 @@ where
                         }
                         "--bank-name" => bank_name = Some(value.to_owned()),
                         "--phoenixd-csv" => phoenixd_csv = Some(PathBuf::from(value)),
+                        "--bitcoin-core-bip329" => bitcoin_core_bip329 = Some(PathBuf::from(value)),
                         "--nodeid" => node_id = Some(value.to_owned()),
                         "--fee-threshold-cents" => {
                             fee_threshold_cents =
@@ -706,6 +734,10 @@ where
 
     let output = output.ok_or_else(|| anyhow::anyhow!("--output is required\n\n{usage}"))?;
 
+    if phoenixd_csv.is_some() && bitcoin_core_bip329.is_some() {
+        bail!("--phoenixd-csv and --bitcoin-core-bip329 are mutually exclusive\n\n{usage}");
+    }
+
     let fiat_mode_env = env::var("FIAT_MODE")
         .ok()
         .map(|v| v.eq_ignore_ascii_case("true"))
@@ -730,6 +762,7 @@ where
         candle_override_minutes: candle_minutes,
         bank_name,
         ignore_balance_mismatch,
+        bitcoin_core_bip329,
         phoenixd_csv,
         node_id,
         fee_threshold_cents,
@@ -782,6 +815,7 @@ mod tests {
                 candle_override_minutes: None,
                 bank_name: None,
                 ignore_balance_mismatch: false,
+                bitcoin_core_bip329: None,
                 phoenixd_csv: None,
                 node_id: None,
                 fee_threshold_cents: None,
@@ -807,6 +841,45 @@ mod tests {
         .expect("args");
 
         assert_eq!(args.candle_override_minutes, Some(60));
+    }
+
+    #[test]
+    fn parses_export_args_with_bitcoin_core_bip329_source() {
+        let args = parse_args_from(
+            vec![
+                "--country".to_owned(),
+                "NL".to_owned(),
+                "--output".to_owned(),
+                "my-wallet.xml".to_owned(),
+                "--bitcoin-core-bip329".to_owned(),
+                "labels.jsonl".to_owned(),
+            ],
+            USAGE,
+        )
+        .expect("args");
+
+        assert_eq!(args.bitcoin_core_bip329, Some("labels.jsonl".into()));
+        assert_eq!(args.phoenixd_csv, None);
+    }
+
+    #[test]
+    fn rejects_multiple_transaction_sources() {
+        let err = parse_args_from(
+            vec![
+                "--country".to_owned(),
+                "NL".to_owned(),
+                "--output".to_owned(),
+                "my-wallet.xml".to_owned(),
+                "--bitcoin-core-bip329".to_owned(),
+                "labels.jsonl".to_owned(),
+                "--phoenixd-csv".to_owned(),
+                "phoenix.csv".to_owned(),
+            ],
+            USAGE,
+        )
+        .expect_err("sources should conflict");
+
+        assert!(err.to_string().contains("mutually exclusive"));
     }
 
     #[test]

--- a/src/commands/received_value.rs
+++ b/src/commands/received_value.rs
@@ -3,11 +3,10 @@ use std::io::{self, IsTerminal, Write};
 use anyhow::{Context, Result, anyhow, bail};
 
 use crate::common::{
-    AppConfig, build_http_client, available_candle_intervals, choose_candle_interval,
+    AppConfig, OutputLocale, available_candle_intervals, build_http_client, choose_candle_interval,
     current_unix_timestamp, fetch_candle_for_timestamp, fetch_kraken_candle_with_fallback,
-    find_unique_receive_transaction, format_local_timestamp, format_number,
-    format_quote_value, parse_candle_interval_minutes, parse_output_locale, sats_to_btc,
-    OutputLocale,
+    find_unique_receive_transaction, format_local_timestamp, format_number, format_quote_value,
+    parse_candle_interval_minutes, parse_output_locale, sats_to_btc,
 };
 
 pub const SUBCOMMAND_NAME: &str = "received-value";
@@ -52,7 +51,9 @@ pub fn run(args: ReceivedValueArgs) -> Result<()> {
         block_time,
         now,
     )?;
-    let locale = args.locale_override.unwrap_or_else(|| config.locale.clone());
+    let locale = args
+        .locale_override
+        .unwrap_or_else(|| config.locale.clone());
 
     let candle = match tor_kraken_client.as_ref() {
         Some(kraken_client) => fetch_kraken_candle_with_fallback(
@@ -80,7 +81,10 @@ pub fn run(args: ReceivedValueArgs) -> Result<()> {
         "candle_vwap: {}",
         format_quote_value(&config.kraken_pair, candle.vwap, &locale)?
     );
-    println!("{}", format_quote_value(&config.kraken_pair, quote_value, &locale)?);
+    println!(
+        "{}",
+        format_quote_value(&config.kraken_pair, quote_value, &locale)?
+    );
 
     Ok(())
 }
@@ -106,7 +110,9 @@ fn run_interactive(config: AppConfig, args: ReceivedValueArgs) -> Result<()> {
     let default_interval = args
         .candle_override_minutes
         .filter(|m| available.contains(m))
-        .or(config.default_candle_minutes.filter(|m| available.contains(m)))
+        .or(config
+            .default_candle_minutes
+            .filter(|m| available.contains(m)))
         .unwrap_or(available[0]);
 
     let available_str = available
@@ -181,9 +187,7 @@ fn prompt_required(label: &str) -> Result<String> {
         stderr.flush().context("failed to flush prompt")?;
 
         line.clear();
-        stdin
-            .read_line(&mut line)
-            .context("failed to read input")?;
+        stdin.read_line(&mut line).context("failed to read input")?;
 
         let trimmed = line.trim();
         if !trimmed.is_empty() {
@@ -200,9 +204,7 @@ fn prompt_with_default(label: &str, default: &str) -> Result<String> {
     write!(stderr, "{label} [{default}]: ").context("failed to write prompt")?;
     stderr.flush().context("failed to flush prompt")?;
 
-    stdin
-        .read_line(&mut line)
-        .context("failed to read input")?;
+    stdin.read_line(&mut line).context("failed to read input")?;
 
     let trimmed = line.trim();
     if trimmed.is_empty() {

--- a/src/commands/reconstruct.rs
+++ b/src/commands/reconstruct.rs
@@ -5,8 +5,8 @@ use anyhow::{Context, Result, bail};
 
 use crate::common::default_bitcoin_datadir;
 use crate::export::camt053::parse_camt053;
-use crate::import::bitcoin_core_rpc::BitcoinCoreRpc;
 use crate::import::TransactionSource;
+use crate::import::bitcoin_core_rpc::BitcoinCoreRpc;
 
 pub const SUBCOMMAND_NAME: &str = "reconstruct";
 
@@ -34,22 +34,23 @@ pub fn run(args: ReconstructArgs) -> Result<()> {
     // Parse the CAMT.053 file
     let xml = std::fs::read_to_string(&args.input)
         .with_context(|| format!("failed to read {}", args.input.display()))?;
-    let parsed = parse_camt053(&xml)
-        .context("failed to parse CAMT.053 file")?;
+    let parsed = parse_camt053(&xml).context("failed to parse CAMT.053 file")?;
 
     if parsed.descriptors.is_empty() {
         bail!("no watch-only descriptors found in XML comments");
     }
 
-    eprintln!("Parsed {} entries, {} descriptor(s) from {}",
+    eprintln!(
+        "Parsed {} entries, {} descriptor(s) from {}",
         parsed.existing_entries.len(),
         parsed.descriptors.len(),
-        args.input.display());
+        args.input.display()
+    );
 
     // Determine wallet name
-    let wallet_name = args.wallet.unwrap_or_else(|| {
-        format!("reconstruct-{}", parsed.account_iban)
-    });
+    let wallet_name = args
+        .wallet
+        .unwrap_or_else(|| format!("reconstruct-{}", parsed.account_iban));
 
     let rpc_url = crate::import::bitcoin_core_rpc::rpc_url_for_chain(&args.chain)?;
     let cookie_path = crate::import::bitcoin_core_rpc::cookie_path(&args.datadir, &args.chain);
@@ -114,7 +115,10 @@ pub fn run(args: ReconstructArgs) -> Result<()> {
         for ref_id in &missing {
             eprintln!("  Missing: {ref_id}");
         }
-        bail!("{} transaction(s) from XML not found in wallet", missing.len());
+        bail!(
+            "{} transaction(s) from XML not found in wallet",
+            missing.len()
+        );
     }
 
     eprintln!("✅ All transactions verified");
@@ -129,18 +133,24 @@ fn create_watch_only_wallet(
     descriptors: &[String],
 ) -> Result<()> {
     let client = reqwest::blocking::Client::builder()
-        .user_agent(concat!(env!("CARGO_PKG_NAME"), "/", env!("CARGO_PKG_VERSION")))
+        .user_agent(concat!(
+            env!("CARGO_PKG_NAME"),
+            "/",
+            env!("CARGO_PKG_VERSION")
+        ))
         .build()
         .context("failed to build HTTP client")?;
 
     // Create blank, watch-only wallet (disable_private_keys=true, blank=true)
     let create_result = rpc_call_raw(
-        &client, rpc_url, cookie,
+        &client,
+        rpc_url,
+        cookie,
         "createwallet",
         &[
             serde_json::json!(wallet_name),
-            serde_json::json!(true),  // disable_private_keys
-            serde_json::json!(true),  // blank
+            serde_json::json!(true), // disable_private_keys
+            serde_json::json!(true), // blank
         ],
     )?;
     if let Some(err) = create_result.get("error").filter(|e| !e.is_null()) {
@@ -199,7 +209,9 @@ fn create_watch_only_wallet(
     eprintln!("Importing {} descriptor(s)...", import_descs.len());
 
     let import_result = rpc_call_raw(
-        &client, &wallet_url, cookie,
+        &client,
+        &wallet_url,
+        cookie,
         "importdescriptors",
         &[serde_json::json!(import_descs)],
     )?;
@@ -224,7 +236,13 @@ fn get_descriptor_checksum(
     cookie: &str,
     desc: &str,
 ) -> Result<String> {
-    let result = rpc_call_raw(client, url, cookie, "getdescriptorinfo", &[serde_json::json!(desc)])?;
+    let result = rpc_call_raw(
+        client,
+        url,
+        cookie,
+        "getdescriptorinfo",
+        &[serde_json::json!(desc)],
+    )?;
     let checksum = result
         .get("result")
         .and_then(|r| r.get("checksum"))
@@ -271,20 +289,26 @@ where
     while let Some(arg) = args.next() {
         match arg.as_str() {
             "--input" => {
-                input = Some(PathBuf::from(
-                    args.next().ok_or_else(|| anyhow::anyhow!("--input requires a value\n\n{usage}"))?,
-                ));
+                input = Some(PathBuf::from(args.next().ok_or_else(|| {
+                    anyhow::anyhow!("--input requires a value\n\n{usage}")
+                })?));
             }
             "--wallet" => {
-                wallet = Some(args.next().ok_or_else(|| anyhow::anyhow!("--wallet requires a value\n\n{usage}"))?);
+                wallet = Some(
+                    args.next()
+                        .ok_or_else(|| anyhow::anyhow!("--wallet requires a value\n\n{usage}"))?,
+                );
             }
             "--datadir" => {
-                datadir = Some(PathBuf::from(
-                    args.next().ok_or_else(|| anyhow::anyhow!("--datadir requires a value\n\n{usage}"))?,
-                ));
+                datadir = Some(PathBuf::from(args.next().ok_or_else(|| {
+                    anyhow::anyhow!("--datadir requires a value\n\n{usage}")
+                })?));
             }
             "--chain" => {
-                chain = Some(args.next().ok_or_else(|| anyhow::anyhow!("--chain requires a value\n\n{usage}"))?);
+                chain = Some(
+                    args.next()
+                        .ok_or_else(|| anyhow::anyhow!("--chain requires a value\n\n{usage}"))?,
+                );
             }
             "-h" | "--help" | "help" => bail!("{usage}"),
             _ => {
@@ -303,8 +327,7 @@ where
         }
     }
 
-    let input = input
-        .ok_or_else(|| anyhow::anyhow!("--input is required\n\n{usage}"))?;
+    let input = input.ok_or_else(|| anyhow::anyhow!("--input is required\n\n{usage}"))?;
 
     let chain = chain
         .or_else(|| env::var("BITCOIN_CHAIN").ok())

--- a/src/common.rs
+++ b/src/common.rs
@@ -7,8 +7,8 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use anyhow::{Context, Result, anyhow, bail};
 use chrono::{DateTime, Local, TimeZone, Utc};
 use fixed_decimal::Decimal as FixedDecimal;
-use icu_decimal::options::{DecimalFormatterOptions, GroupingStrategy};
 use icu_decimal::DecimalFormatter;
+use icu_decimal::options::{DecimalFormatterOptions, GroupingStrategy};
 use icu_locale::Locale;
 use reqwest::StatusCode;
 use reqwest::blocking::Client;
@@ -49,9 +49,8 @@ impl OutputLocale {
         let mut options = DecimalFormatterOptions::default();
         options.grouping_strategy = Some(GroupingStrategy::Never);
 
-        DecimalFormatter::try_new(self.0.clone().into(), options).with_context(|| {
-            format!("locale {} is not available for decimal formatting", self.0)
-        })
+        DecimalFormatter::try_new(self.0.clone().into(), options)
+            .with_context(|| format!("locale {} is not available for decimal formatting", self.0))
     }
 }
 
@@ -198,8 +197,8 @@ pub fn parse_output_locale(value: &str, name: &str) -> Result<OutputLocale> {
         bail!("invalid {name} value: empty");
     }
 
-    let locale = Locale::from_str(trimmed)
-        .with_context(|| format!("invalid {name} value: {trimmed}"))?;
+    let locale =
+        Locale::from_str(trimmed).with_context(|| format!("invalid {name} value: {trimmed}"))?;
 
     DecimalFormatter::try_new(locale.clone().into(), Default::default())
         .with_context(|| format!("unsupported {name} value: {trimmed}"))?;
@@ -493,8 +492,14 @@ fn parse_kraken_ohlc_response(
         .with_context(|| format!("failed to decode Kraken response from {url}"))?;
 
     if !payload.error.is_empty() {
-        if payload.error.iter().any(|e| e.contains("Too many requests")) {
-            return Err(anyhow::Error::new(RateLimitedError { retry_after_secs: None }));
+        if payload
+            .error
+            .iter()
+            .any(|e| e.contains("Too many requests"))
+        {
+            return Err(anyhow::Error::new(RateLimitedError {
+                retry_after_secs: None,
+            }));
         }
         bail!("Kraken API returned errors: {}", payload.error.join(", "));
     }
@@ -507,7 +512,12 @@ fn parse_kraken_ohlc_response(
         .get(&config.kraken_pair)
         .and_then(Value::as_array)
         .cloned()
-        .ok_or_else(|| anyhow!("Kraken response does not include pair {}", config.kraken_pair))
+        .ok_or_else(|| {
+            anyhow!(
+                "Kraken response does not include pair {}",
+                config.kraken_pair
+            )
+        })
 }
 
 fn parse_candle_row(row: &Value) -> Option<Candle> {
@@ -556,11 +566,7 @@ where
         .unwrap_or_else(|| format!("unix:{timestamp}"))
 }
 
-pub fn format_quote_value(
-    kraken_pair: &str,
-    value: f64,
-    locale: &OutputLocale,
-) -> Result<String> {
+pub fn format_quote_value(kraken_pair: &str, value: f64, locale: &OutputLocale) -> Result<String> {
     Ok(format!(
         "{}{}",
         quote_value_prefix(kraken_pair),
@@ -622,7 +628,9 @@ impl AppConfig {
         Ok(Self {
             mempool_base_url: env_or_default(get_env("MEMPOOL_BASE_URL"), DEFAULT_MEMPOOL_BASE_URL),
             kraken_pair: env_or_default(get_env("KRAKEN_PAIR"), DEFAULT_KRAKEN_PAIR),
-            default_candle_minutes: parse_default_candle_minutes(get_env("DEFAULT_CANDLE_MINUTES"))?,
+            default_candle_minutes: parse_default_candle_minutes(get_env(
+                "DEFAULT_CANDLE_MINUTES",
+            ))?,
             locale: parse_output_locale(
                 &env_or_default(get_env("LOCALE"), DEFAULT_LOCALE),
                 "LOCALE",
@@ -746,16 +754,16 @@ mod tests {
 
     #[test]
     fn env_default_candle_minutes_is_used_when_present() {
-        let interval_minutes = choose_candle_interval(None, Some(60), 1_000, 1_000 + 60)
-            .expect("interval");
+        let interval_minutes =
+            choose_candle_interval(None, Some(60), 1_000, 1_000 + 60).expect("interval");
 
         assert_eq!(interval_minutes, 60);
     }
 
     #[test]
     fn cli_candle_override_beats_env_default() {
-        let interval_minutes = choose_candle_interval(Some(15), Some(60), 1_000, 1_000 + 60)
-            .expect("interval");
+        let interval_minutes =
+            choose_candle_interval(Some(15), Some(60), 1_000, 1_000 + 60).expect("interval");
 
         assert_eq!(interval_minutes, 15);
     }
@@ -851,7 +859,10 @@ mod tests {
         })
         .expect_err("invalid config");
 
-        assert!(err.to_string().contains("unsupported DEFAULT_CANDLE_MINUTES value: 2"));
+        assert!(
+            err.to_string()
+                .contains("unsupported DEFAULT_CANDLE_MINUTES value: 2")
+        );
     }
 
     #[test]
@@ -921,7 +932,9 @@ mod tests {
             "1970-01-01T01:00:00+01:00"
         );
         let local_text = format_local_timestamp(0);
-        assert!(local_text.ends_with(":00") || local_text.contains('+') || local_text.contains('-'));
+        assert!(
+            local_text.ends_with(":00") || local_text.contains('+') || local_text.contains('-')
+        );
     }
 
     #[test]

--- a/src/exchange_rate.rs
+++ b/src/exchange_rate.rs
@@ -8,7 +8,9 @@ use std::time::Duration;
 use anyhow::{Result, anyhow};
 use reqwest::blocking::Client;
 
-use crate::common::{AppConfig, Candle, RateLimitedError, build_http_client, fetch_candle_for_timestamp};
+use crate::common::{
+    AppConfig, Candle, RateLimitedError, build_http_client, fetch_candle_for_timestamp,
+};
 
 pub const CACHE_DIR: &str = ".cache";
 pub const CACHE_FILE: &str = "rates.json";
@@ -58,7 +60,10 @@ impl KrakenProvider {
 
     /// Returns true if new entries were written to the disk cache.
     pub fn cache_grew(&self) -> bool {
-        self.cache.lock().map(|c| c.len() > self.initial_cache_size).unwrap_or(false)
+        self.cache
+            .lock()
+            .map(|c| c.len() > self.initial_cache_size)
+            .unwrap_or(false)
     }
 
     fn fetch_candle(&self, timestamp: i64, interval_minutes: u32) -> Result<Candle> {

--- a/src/export/camt053.rs
+++ b/src/export/camt053.rs
@@ -24,8 +24,16 @@ fn write_xml(stmt: &Statement, out: &mut dyn Write) -> Result<()> {
 
     // Group Header (mandatory in CAMT.053)
     writeln!(out, "    <GrpHdr>")?;
-    writeln!(out, "      <MsgId>{}</MsgId>", xml_escape(&stmt.statement_id))?;
-    writeln!(out, "      <CreDtTm>{}T00:00:00</CreDtTm>", stmt.statement_date)?;
+    writeln!(
+        out,
+        "      <MsgId>{}</MsgId>",
+        xml_escape(&stmt.statement_id)
+    )?;
+    writeln!(
+        out,
+        "      <CreDtTm>{}T00:00:00</CreDtTm>",
+        stmt.statement_date
+    )?;
     writeln!(out, "      <MsgPgntn>")?;
     writeln!(out, "        <PgNb>1</PgNb>")?;
     writeln!(out, "        <LastPgInd>true</LastPgInd>")?;
@@ -35,7 +43,11 @@ fn write_xml(stmt: &Statement, out: &mut dyn Write) -> Result<()> {
     writeln!(out, "    <Stmt>")?;
     writeln!(out, "      <Id>{}</Id>", xml_escape(&stmt.statement_id))?;
     writeln!(out, "      <ElctrncSeqNb>1</ElctrncSeqNb>")?;
-    writeln!(out, "      <CreDtTm>{}T00:00:00</CreDtTm>", stmt.statement_date)?;
+    writeln!(
+        out,
+        "      <CreDtTm>{}T00:00:00</CreDtTm>",
+        stmt.statement_date
+    )?;
 
     // Account
     let bic = bic_from_iban(&stmt.account_iban);
@@ -55,10 +67,22 @@ fn write_xml(stmt: &Statement, out: &mut dyn Write) -> Result<()> {
     writeln!(out, "      </Acct>")?;
 
     // Opening balance (fiat)
-    write_balance(out, "OPBD", stmt.opening_balance_cents, &stmt.currency, &opening_date(stmt))?;
+    write_balance(
+        out,
+        "OPBD",
+        stmt.opening_balance_cents,
+        &stmt.currency,
+        &opening_date(stmt),
+    )?;
 
     // Closing balance
-    write_balance(out, "CLBD", stmt.closing_balance_cents, &stmt.currency, &stmt.statement_date)?;
+    write_balance(
+        out,
+        "CLBD",
+        stmt.closing_balance_cents,
+        &stmt.currency,
+        &stmt.statement_date,
+    )?;
 
     // Entries
     for entry in &stmt.entries {
@@ -67,7 +91,10 @@ fn write_xml(stmt: &Statement, out: &mut dyn Write) -> Result<()> {
 
     // Watch-only descriptors as XML comments (for wallet reconstruction)
     if !stmt.descriptors.is_empty() {
-        writeln!(out, "    <!-- Watch-only descriptors (privacy-sensitive — see README) -->")?;
+        writeln!(
+            out,
+            "    <!-- Watch-only descriptors (privacy-sensitive — see README) -->"
+        )?;
         for desc in &stmt.descriptors {
             writeln!(out, "    <!-- {} -->", xml_escape_comment(desc))?;
         }
@@ -78,11 +105,21 @@ fn write_xml(stmt: &Statement, out: &mut dyn Write) -> Result<()> {
         let abs_sats = stmt.opening_balance_sats.unsigned_abs();
         let whole = abs_sats / 100_000_000;
         let frac = abs_sats % 100_000_000;
-        let sign = if stmt.opening_balance_sats < 0 { "-" } else { "" };
-        if let Some(rate) = stmt.opening_rate {
-            writeln!(out, "    <!-- BTC opening balance: {sign}{whole}.{frac:08} BTC @ {rate:.2} -->")?;
+        let sign = if stmt.opening_balance_sats < 0 {
+            "-"
         } else {
-            writeln!(out, "    <!-- BTC opening balance: {sign}{whole}.{frac:08} BTC -->")?;
+            ""
+        };
+        if let Some(rate) = stmt.opening_rate {
+            writeln!(
+                out,
+                "    <!-- BTC opening balance: {sign}{whole}.{frac:08} BTC @ {rate:.2} -->"
+            )?;
+        } else {
+            writeln!(
+                out,
+                "    <!-- BTC opening balance: {sign}{whole}.{frac:08} BTC -->"
+            )?;
         }
     }
 
@@ -97,7 +134,13 @@ fn opening_date(stmt: &Statement) -> String {
     stmt.opening_date.clone()
 }
 
-fn write_balance(out: &mut dyn Write, code: &str, amount_cents: i64, currency: &str, date: &str) -> Result<()> {
+fn write_balance(
+    out: &mut dyn Write,
+    code: &str,
+    amount_cents: i64,
+    currency: &str,
+    date: &str,
+) -> Result<()> {
     let (cd_indicator, abs_cents) = if amount_cents >= 0 {
         ("CRDT", amount_cents)
     } else {
@@ -112,7 +155,10 @@ fn write_balance(out: &mut dyn Write, code: &str, amount_cents: i64, currency: &
     writeln!(out, "            <Cd>{code}</Cd>")?;
     writeln!(out, "          </CdOrPrtry>")?;
     writeln!(out, "        </Tp>")?;
-    writeln!(out, "        <Amt Ccy=\"{currency}\">{whole}.{frac:02}</Amt>")?;
+    writeln!(
+        out,
+        "        <Amt Ccy=\"{currency}\">{whole}.{frac:02}</Amt>"
+    )?;
     writeln!(out, "        <CdtDbtInd>{cd_indicator}</CdtDbtInd>")?;
     writeln!(out, "        <Dt>")?;
     writeln!(out, "          <Dt>{date}</Dt>")?;
@@ -127,8 +173,15 @@ fn write_entry(out: &mut dyn Write, entry: &Entry, currency: &str) -> Result<()>
     let (whole, frac) = cents_to_parts(entry.amount_cents);
 
     writeln!(out, "      <Ntry>")?;
-    writeln!(out, "        <NtryRef>{}</NtryRef>", xml_escape(&entry.entry_ref))?;
-    writeln!(out, "        <Amt Ccy=\"{currency}\">{whole}.{frac:02}</Amt>")?;
+    writeln!(
+        out,
+        "        <NtryRef>{}</NtryRef>",
+        xml_escape(&entry.entry_ref)
+    )?;
+    writeln!(
+        out,
+        "        <Amt Ccy=\"{currency}\">{whole}.{frac:02}</Amt>"
+    )?;
     writeln!(out, "        <CdtDbtInd>{cd_indicator}</CdtDbtInd>")?;
     writeln!(out, "        <Sts>BOOK</Sts>")?;
     writeln!(out, "        <BookgDt>")?;
@@ -235,8 +288,8 @@ pub struct Camt053ParseResult {
 
 /// Parse an existing CAMT.053 XML file to extract data for append mode.
 pub fn parse_camt053(xml: &str) -> Result<Camt053ParseResult> {
-    use quick_xml::events::Event;
     use quick_xml::Reader;
+    use quick_xml::events::Event;
 
     let mut reader = Reader::from_str(xml);
 
@@ -379,7 +432,9 @@ pub fn parse_camt053(xml: &str) -> Result<Camt053ParseResult> {
                             bal_amount_cents = parse_amount_cents(&text)?;
                         }
                         "CdtDbtInd" => bal_is_credit = text == "CRDT",
-                        "Dt" | "DtTm" if path_contains(&path, "Bal") && path_contains(&path, "Dt") => {
+                        "Dt" | "DtTm"
+                            if path_contains(&path, "Bal") && path_contains(&path, "Dt") =>
+                        {
                             let trimmed = text.trim();
                             if bal_date.is_empty() && !trimmed.is_empty() {
                                 bal_date = trimmed.to_owned();
@@ -444,7 +499,12 @@ fn parse_amount_cents(s: &str) -> Result<i64> {
     let frac: i64 = if parts.len() > 1 {
         let frac_str = parts[1];
         match frac_str.len() {
-            1 => frac_str.parse::<i64>().context("invalid amount fractional part")? * 10,
+            1 => {
+                frac_str
+                    .parse::<i64>()
+                    .context("invalid amount fractional part")?
+                    * 10
+            }
             2 => frac_str.parse().context("invalid amount fractional part")?,
             _ => bail!("unexpected decimal places in amount: {s}"),
         }
@@ -535,8 +595,8 @@ mod tests {
         assert!(xml.contains("bc1qtest - Received 0.05263158 BTC @ 95000.00"));
         // Bank transaction codes
         assert!(xml.contains("<Cd>PMNT</Cd>"));
-        assert!(xml.contains("<Cd>RCDT</Cd>"));  // credit entry
-        assert!(xml.contains("<Cd>ICDT</Cd>"));  // debit entry (fee)
+        assert!(xml.contains("<Cd>RCDT</Cd>")); // credit entry
+        assert!(xml.contains("<Cd>ICDT</Cd>")); // debit entry (fee)
         assert!(xml.contains("<SubFmlyCd>OTHR</SubFmlyCd>"));
     }
 
@@ -550,7 +610,10 @@ mod tests {
 
     #[test]
     fn escapes_xml_special_chars() {
-        assert_eq!(xml_escape("a<b>c&d\"e'f"), "a&lt;b&gt;c&amp;d&quot;e&apos;f");
+        assert_eq!(
+            xml_escape("a<b>c&d\"e'f"),
+            "a&lt;b&gt;c&amp;d&quot;e&apos;f"
+        );
     }
 
     #[test]
@@ -585,8 +648,16 @@ mod tests {
         assert_eq!(parsed.opening_date, Some("2025-01-02".to_owned()));
         assert_eq!(parsed.closing_balance_cents, 499_985);
         assert_eq!(parsed.existing_entry_refs.len(), 2);
-        assert!(parsed.existing_entry_refs.contains("100:abcdef01234567890abc:0"));
-        assert!(parsed.existing_entry_refs.contains(":100:abcdef01234567890abc:fee"));
+        assert!(
+            parsed
+                .existing_entry_refs
+                .contains("100:abcdef01234567890abc:0")
+        );
+        assert!(
+            parsed
+                .existing_entry_refs
+                .contains(":100:abcdef01234567890abc:fee")
+        );
         assert_eq!(parsed.last_booking_date, Some("2025-01-02".to_owned()));
 
         // Verify entries were fully parsed

--- a/src/iban.rs
+++ b/src/iban.rs
@@ -146,7 +146,10 @@ mod tests {
         let node_id = "03864ef025fde8fb587d989186ce6a4a186895ee44a926bfc370e2c366597a3f8f";
         let iban = iban_from_node_id(node_id, "FR").unwrap();
         assert!(iban.starts_with("FR"));
-        assert!(iban.contains("LNBT"), "IBAN should use LNBT bank code: {iban}");
+        assert!(
+            iban.contains("LNBT"),
+            "IBAN should use LNBT bank code: {iban}"
+        );
         assert_eq!(iban.len(), 18);
         let numeric = alpha_to_numeric(&format!("{}{}", &iban[4..], &iban[..4]));
         assert_eq!(mod97(&numeric), 1, "IBAN {iban} should pass mod-97 check");

--- a/src/import/bitcoin_core_bip329.rs
+++ b/src/import/bitcoin_core_bip329.rs
@@ -1,0 +1,268 @@
+use std::collections::HashMap;
+use std::fs;
+use std::path::Path;
+
+use anyhow::{Context, Result, anyhow, bail};
+use chrono::DateTime;
+use serde::Deserialize;
+
+use super::{TransactionSource, TxCategory, WalletTransaction};
+
+/// Bitcoin Core rich BIP329 JSONL transaction source.
+///
+/// This parser targets the experimental `bitcoin-wallet exportlabels` format
+/// from Sjors/bitcoin#115, where `output` records carry accounting context.
+pub struct BitcoinCoreBip329 {
+    transactions: Vec<WalletTransaction>,
+    descriptors: Vec<String>,
+    fingerprint: String,
+}
+
+impl BitcoinCoreBip329 {
+    pub fn from_path(path: &Path) -> Result<Self> {
+        let jsonl = fs::read_to_string(path)
+            .with_context(|| format!("failed to read BIP329 file {}", path.display()))?;
+        Self::from_str(&jsonl)
+    }
+
+    pub fn from_str(jsonl: &str) -> Result<Self> {
+        let mut tx_fees: HashMap<String, i64> = HashMap::new();
+        let mut descriptors = Vec::new();
+        let mut output_records = Vec::new();
+        let mut fingerprint: Option<String> = None;
+
+        for (idx, line) in jsonl.lines().enumerate() {
+            let line_number = idx + 1;
+            let line = line.trim();
+            if line.is_empty() {
+                continue;
+            }
+
+            let record: Bip329Record = serde_json::from_str(line).with_context(|| {
+                format!("failed to parse BIP329 JSON object on line {line_number}")
+            })?;
+
+            match record.record_type.as_str() {
+                "tx" => {
+                    if let Some(fee) = record.fee {
+                        tx_fees.insert(record.ref_id.clone(), fee);
+                    }
+                    if fingerprint.is_none() {
+                        fingerprint = record
+                            .origin
+                            .as_deref()
+                            .and_then(parse_fingerprint_from_origin);
+                    }
+                }
+                "output" => {
+                    output_records.push((line_number, record));
+                }
+                "descriptor" => {
+                    descriptors.push(record.ref_id.clone());
+                    if fingerprint.is_none() {
+                        fingerprint = parse_fingerprint_from_descriptor(&record.ref_id);
+                    }
+                }
+                _ => {}
+            }
+        }
+
+        let mut transactions = Vec::new();
+        for (line_number, record) in output_records {
+            let Some(category) = record.category.as_deref() else {
+                continue;
+            };
+            let category = match category {
+                "send" => TxCategory::Send,
+                "receive" => TxCategory::Receive,
+                _ => continue,
+            };
+
+            if record.time.is_none() || record.blockhash.is_none() {
+                eprintln!(
+                    "Skipping unconfirmed BIP329 output {} on line {line_number}",
+                    record.ref_id
+                );
+                continue;
+            }
+
+            let (txid, vout) = parse_output_ref(&record.ref_id)
+                .with_context(|| format!("invalid output ref on line {line_number}"))?;
+            let block_time = parse_bip329_time(record.time.as_deref().unwrap())
+                .with_context(|| format!("invalid BIP329 time on line {line_number}"))?;
+            let amount_sats = match (record.wallet_value, record.value) {
+                (Some(wallet_value), _) => wallet_value,
+                (None, Some(value)) if category == TxCategory::Send => -value,
+                (None, Some(value)) => value,
+                (None, None) => {
+                    bail!(
+                        "BIP329 output record on line {line_number} is missing wallet_value/value"
+                    )
+                }
+            };
+
+            let fee_sats = if category == TxCategory::Send {
+                record.fee.or_else(|| tx_fees.get(&txid).copied())
+            } else {
+                None
+            };
+
+            transactions.push(WalletTransaction {
+                txid,
+                vout,
+                amount_sats,
+                fee_sats,
+                category,
+                block_time,
+                block_height: record.height.unwrap_or(0),
+                block_hash: record.blockhash.unwrap_or_default(),
+                address: record.address.unwrap_or_default(),
+                label: record.label.unwrap_or_default(),
+                payment_hash: None,
+                kind: super::TxKind::Default,
+            });
+        }
+
+        transactions.sort_by(|a, b| {
+            a.block_time
+                .cmp(&b.block_time)
+                .then(a.block_height.cmp(&b.block_height))
+                .then(a.vout.cmp(&b.vout))
+        });
+
+        let fingerprint = fingerprint.ok_or_else(|| {
+            anyhow!("BIP329 export did not contain a descriptor/origin fingerprint")
+        })?;
+
+        Ok(Self {
+            transactions,
+            descriptors,
+            fingerprint,
+        })
+    }
+
+    pub fn fingerprint(&self) -> &str {
+        &self.fingerprint
+    }
+
+    pub fn descriptors(&self) -> &[String] {
+        &self.descriptors
+    }
+}
+
+impl TransactionSource for BitcoinCoreBip329 {
+    fn list_transactions(&self) -> Result<Vec<WalletTransaction>> {
+        Ok(self.transactions.clone())
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct Bip329Record {
+    #[serde(rename = "type")]
+    record_type: String,
+    #[serde(rename = "ref")]
+    ref_id: String,
+    label: Option<String>,
+    origin: Option<String>,
+    category: Option<String>,
+    value: Option<i64>,
+    wallet_value: Option<i64>,
+    fee: Option<i64>,
+    height: Option<u32>,
+    time: Option<String>,
+    blockhash: Option<String>,
+    address: Option<String>,
+}
+
+fn parse_output_ref(ref_id: &str) -> Result<(String, u32)> {
+    let (txid, vout) = ref_id
+        .split_once(':')
+        .ok_or_else(|| anyhow!("expected txid:vout"))?;
+    if txid.len() != 64 || !txid.chars().all(|c| c.is_ascii_hexdigit()) {
+        bail!("invalid txid in output ref {ref_id}");
+    }
+    if vout.contains(':') {
+        bail!("invalid output ref {ref_id}");
+    }
+    let vout = vout
+        .parse::<u32>()
+        .with_context(|| format!("invalid vout in output ref {ref_id}"))?;
+    Ok((txid.to_owned(), vout))
+}
+
+fn parse_bip329_time(time: &str) -> Result<i64> {
+    Ok(DateTime::parse_from_rfc3339(time)?.timestamp())
+}
+
+fn parse_fingerprint_from_origin(origin: &str) -> Option<String> {
+    let start = origin.find('[')? + 1;
+    parse_fingerprint_at(&origin[start..])
+}
+
+fn parse_fingerprint_from_descriptor(desc: &str) -> Option<String> {
+    let start = desc.find('[')? + 1;
+    parse_fingerprint_at(&desc[start..])
+}
+
+fn parse_fingerprint_at(value: &str) -> Option<String> {
+    let fp = value.get(..8)?;
+    if fp.chars().all(|c| c.is_ascii_hexdigit()) {
+        Some(fp.to_lowercase())
+    } else {
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const TXID_RECEIVE: &str = "1111111111111111111111111111111111111111111111111111111111111111";
+    const TXID_SEND: &str = "2222222222222222222222222222222222222222222222222222222222222222";
+    const BLOCKHASH: &str = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+
+    #[test]
+    fn parses_rich_bip329_records_into_wallet_transactions() {
+        let jsonl = format!(
+            r#"{{"type":"tx","ref":"{TXID_RECEIVE}","value":5000,"origin":"wpkh([AABBCCDD/84'/1'/0'])","height":42,"time":"2025-01-02T11:00:00Z","blockhash":"{BLOCKHASH}"}}
+{{"type":"output","ref":"{TXID_RECEIVE}:0","label":"Salary January","category":"receive","wallet_value":5000,"value":5000,"height":42,"time":"2025-01-02T11:00:00Z","blockhash":"{BLOCKHASH}","address":"bcrt1qreceive"}}
+{{"type":"tx","ref":"{TXID_SEND}","value":-3000,"fee":141,"origin":"wpkh([AABBCCDD/84'/1'/0'])","height":43,"time":"2025-01-03T12:00:00Z","blockhash":"{BLOCKHASH}"}}
+{{"type":"output","ref":"{TXID_SEND}:1","label":"Exchange","category":"send","wallet_value":-3000,"value":3000,"height":43,"time":"2025-01-03T12:00:00Z","blockhash":"{BLOCKHASH}","address":"bcrt1qsend"}}
+{{"type":"descriptor","ref":"wpkh([aabbccdd/84'/1'/0']tpub.../0/*)#abc","label":"descriptor"}}
+"#
+        );
+
+        let source = BitcoinCoreBip329::from_str(&jsonl).expect("parse BIP329");
+        assert_eq!(source.fingerprint(), "aabbccdd");
+        assert_eq!(source.descriptors().len(), 1);
+
+        let txs = source.list_transactions().expect("transactions");
+        assert_eq!(txs.len(), 2);
+        assert_eq!(txs[0].txid, TXID_RECEIVE);
+        assert_eq!(txs[0].vout, 0);
+        assert_eq!(txs[0].amount_sats, 5000);
+        assert_eq!(txs[0].fee_sats, None);
+        assert_eq!(txs[0].category, TxCategory::Receive);
+        assert_eq!(txs[0].block_time, 1_735_815_600);
+        assert_eq!(txs[0].block_height, 42);
+        assert_eq!(txs[0].block_hash, BLOCKHASH);
+        assert_eq!(txs[0].label, "Salary January");
+
+        assert_eq!(txs[1].txid, TXID_SEND);
+        assert_eq!(txs[1].vout, 1);
+        assert_eq!(txs[1].amount_sats, -3000);
+        assert_eq!(txs[1].fee_sats, Some(141));
+        assert_eq!(txs[1].category, TxCategory::Send);
+    }
+
+    #[test]
+    fn skips_unconfirmed_outputs() {
+        let jsonl = format!(
+            r#"{{"type":"descriptor","ref":"wpkh([aabbccdd/84'/1'/0']tpub.../0/*)#abc","label":"descriptor"}}
+{{"type":"output","ref":"{TXID_RECEIVE}:0","category":"receive","wallet_value":5000}}
+"#
+        );
+        let source = BitcoinCoreBip329::from_str(&jsonl).expect("parse BIP329");
+        assert!(source.list_transactions().unwrap().is_empty());
+    }
+}

--- a/src/import/bitcoin_core_rpc.rs
+++ b/src/import/bitcoin_core_rpc.rs
@@ -18,7 +18,11 @@ pub struct BitcoinCoreRpc {
 impl BitcoinCoreRpc {
     pub fn new(wallet: &str, datadir: &Path, chain: &str) -> Result<Self> {
         let client = Client::builder()
-            .user_agent(concat!(env!("CARGO_PKG_NAME"), "/", env!("CARGO_PKG_VERSION")))
+            .user_agent(concat!(
+                env!("CARGO_PKG_NAME"),
+                "/",
+                env!("CARGO_PKG_VERSION")
+            ))
             .build()
             .context("failed to build RPC HTTP client")?;
 
@@ -39,7 +43,11 @@ impl BitcoinCoreRpc {
     /// Create with an explicit RPC URL (for testing).
     pub fn with_url(rpc_url: &str, wallet: &str, datadir: &Path, chain: &str) -> Result<Self> {
         let client = Client::builder()
-            .user_agent(concat!(env!("CARGO_PKG_NAME"), "/", env!("CARGO_PKG_VERSION")))
+            .user_agent(concat!(
+                env!("CARGO_PKG_NAME"),
+                "/",
+                env!("CARGO_PKG_VERSION")
+            ))
             .build()
             .context("failed to build RPC HTTP client")?;
 
@@ -70,7 +78,10 @@ impl BitcoinCoreRpc {
 
     /// Get watch-only (public) descriptors for addresses that received coins.
     /// Returns multipath descriptors (BIP-389) combining receive and change paths.
-    pub fn get_receive_descriptors(&self, receive_addresses: &std::collections::HashSet<String>) -> Result<Vec<String>> {
+    pub fn get_receive_descriptors(
+        &self,
+        receive_addresses: &std::collections::HashSet<String>,
+    ) -> Result<Vec<String>> {
         let descriptors = self.list_descriptors()?;
 
         let mut result = Vec::new();
@@ -83,10 +94,7 @@ impl BitcoinCoreRpc {
             let range = desc_info.range.unwrap_or([0, 0]);
             let derived: Vec<String> = self.rpc_call(
                 "deriveaddresses",
-                &[
-                    serde_json::json!(desc_info.desc),
-                    serde_json::json!(range),
-                ],
+                &[serde_json::json!(desc_info.desc), serde_json::json!(range)],
             )?;
 
             if derived.iter().any(|a| receive_addresses.contains(a)) {
@@ -101,7 +109,11 @@ impl BitcoinCoreRpc {
 
     /// Combine a receive descriptor (`.../0/*`) with its matching change descriptor (`.../1/*`)
     /// into a single BIP-389 multipath descriptor (`.../&lt;0;1&gt;/*`).
-    fn build_multipath_descriptor(&self, receive_desc: &str, all_descriptors: &[DescriptorInfo]) -> Option<String> {
+    fn build_multipath_descriptor(
+        &self,
+        receive_desc: &str,
+        all_descriptors: &[DescriptorInfo],
+    ) -> Option<String> {
         // Strip checksum from receive descriptor
         let recv_bare = receive_desc.split('#').next()?;
 
@@ -115,9 +127,9 @@ impl BitcoinCoreRpc {
         let expected_change = format!("{prefix}/1/*)");
 
         // Find matching internal descriptor
-        let found = all_descriptors.iter().any(|d| {
-            d.internal && d.desc.split('#').next() == Some(&expected_change)
-        });
+        let found = all_descriptors
+            .iter()
+            .any(|d| d.internal && d.desc.split('#').next() == Some(&expected_change));
 
         if found {
             Some(format!("{prefix}/<0;1>/*)"))
@@ -139,11 +151,16 @@ impl BitcoinCoreRpc {
     /// List currently loaded wallets (non-wallet-specific RPC call).
     pub fn list_wallets(rpc_url: &str, cookie: &str) -> Result<Vec<String>> {
         let client = Client::builder()
-            .user_agent(concat!(env!("CARGO_PKG_NAME"), "/", env!("CARGO_PKG_VERSION")))
+            .user_agent(concat!(
+                env!("CARGO_PKG_NAME"),
+                "/",
+                env!("CARGO_PKG_VERSION")
+            ))
             .build()
             .context("failed to build RPC HTTP client")?;
 
-        let response: RpcResponse<Vec<String>> = rpc_request(&client, rpc_url, cookie, "listwallets", &[])?;
+        let response: RpcResponse<Vec<String>> =
+            rpc_request(&client, rpc_url, cookie, "listwallets", &[])?;
 
         response.result.ok_or_else(|| match response.error {
             Some(err) => anyhow!("listwallets failed: {} (code {})", err.message, err.code),
@@ -154,10 +171,13 @@ impl BitcoinCoreRpc {
     /// Get the wallet's confirmed balance in satoshis.
     pub fn get_balance(&self) -> Result<i64> {
         // minconf=1 to exclude unconfirmed transactions (matching listtransactions filtering)
-        let btc: f64 = self.rpc_call("getbalance", &[
-            serde_json::json!("*"),   // dummy (deprecated first arg)
-            serde_json::json!(1),     // minconf
-        ])?;
+        let btc: f64 = self.rpc_call(
+            "getbalance",
+            &[
+                serde_json::json!("*"), // dummy (deprecated first arg)
+                serde_json::json!(1),   // minconf
+            ],
+        )?;
         Ok(btc_to_sats(btc))
     }
 
@@ -167,7 +187,8 @@ impl BitcoinCoreRpc {
         params: &[serde_json::Value],
     ) -> Result<T> {
         let url = format!("{}/wallet/{}", self.rpc_url, self.wallet);
-        let response: RpcResponse<T> = rpc_request(&self.client, &url, &self.cookie, method, params)?;
+        let response: RpcResponse<T> =
+            rpc_request(&self.client, &url, &self.cookie, method, params)?;
 
         response.result.ok_or_else(|| match response.error {
             Some(err) => anyhow!("{method} failed: {} (code {})", err.message, err.code),
@@ -256,7 +277,10 @@ impl TransactionSource for BitcoinCoreRpc {
             for tx in &raw_txs {
                 if tx.confirmations < 1 {
                     if tx.walletconflicts.is_empty() && tx.replaces_txid.is_none() {
-                        eprintln!("⚠️  Skipping unconfirmed transaction {} (no block hash yet)", tx.txid);
+                        eprintln!(
+                            "⚠️  Skipping unconfirmed transaction {} (no block hash yet)",
+                            tx.txid
+                        );
                     }
                     continue;
                 }
@@ -360,10 +384,7 @@ mod tests {
             parse_fingerprint_from_descriptor("tr([AABBCCDD/86'/0'/0']xpub6...)"),
             Some("aabbccdd".to_owned())
         );
-        assert_eq!(
-            parse_fingerprint_from_descriptor("wpkh(xpub6...)"),
-            None
-        );
+        assert_eq!(parse_fingerprint_from_descriptor("wpkh(xpub6...)"), None);
     }
 
     #[test]

--- a/src/import/mod.rs
+++ b/src/import/mod.rs
@@ -1,3 +1,4 @@
+pub mod bitcoin_core_bip329;
 pub mod bitcoin_core_rpc;
 pub mod phoenixd_csv;
 

--- a/src/import/phoenixd_csv.rs
+++ b/src/import/phoenixd_csv.rs
@@ -41,26 +41,30 @@ impl PhoenixdCsv {
     /// include fees in amount_msat, and channel-opening credit consumption is
     /// reflected via fee_credit_msat.
     pub fn wallet_balance_sats(&self) -> i64 {
-        let total_msat: i64 = self.records.iter().map(|r| {
-            if r.tx_type == "liquidity_purchase" {
-                // Standalone fee: accounting debits gross fee, ignoring
-                // amount_msat (which equals the fee total).
-                -(r.mining_fee_sat * 1000 + r.service_fee_msat)
-            } else {
-                let is_channel_opening = r.tx_type == "lightning_received"
-                    && (r.mining_fee_sat > 0 || r.service_fee_msat > 0);
-                if is_channel_opening {
-                    // Channel opening: account_balance = channel + fee_credit.
-                    // amount_msat enters the channel, fee_credit_msat is
-                    // consumed (negative).  Sum = account balance change.
-                    r.amount_msat + r.fee_credit_msat
+        let total_msat: i64 = self
+            .records
+            .iter()
+            .map(|r| {
+                if r.tx_type == "liquidity_purchase" {
+                    // Standalone fee: accounting debits gross fee, ignoring
+                    // amount_msat (which equals the fee total).
+                    -(r.mining_fee_sat * 1000 + r.service_fee_msat)
                 } else {
-                    // Non-channel: positive credit is income, negative
-                    // credit doesn't occur (only on channel openings).
-                    r.amount_msat + r.fee_credit_msat.max(0)
+                    let is_channel_opening = r.tx_type == "lightning_received"
+                        && (r.mining_fee_sat > 0 || r.service_fee_msat > 0);
+                    if is_channel_opening {
+                        // Channel opening: account_balance = channel + fee_credit.
+                        // amount_msat enters the channel, fee_credit_msat is
+                        // consumed (negative).  Sum = account balance change.
+                        r.amount_msat + r.fee_credit_msat
+                    } else {
+                        // Non-channel: positive credit is income, negative
+                        // credit doesn't occur (only on channel openings).
+                        r.amount_msat + r.fee_credit_msat.max(0)
+                    }
                 }
-            }
-        }).sum();
+            })
+            .sum();
         msat_to_sat(total_msat)
     }
 
@@ -87,13 +91,17 @@ impl PhoenixdCsv {
                 date: fields[0].clone(),
                 id: fields[1].clone(),
                 tx_type: fields[2].clone(),
-                amount_msat: fields[3].parse::<i64>()
+                amount_msat: fields[3]
+                    .parse::<i64>()
                     .with_context(|| format!("invalid amount_msat: {}", fields[3]))?,
-                fee_credit_msat: fields[4].parse::<i64>()
+                fee_credit_msat: fields[4]
+                    .parse::<i64>()
                     .with_context(|| format!("invalid fee_credit_msat: {}", fields[4]))?,
-                mining_fee_sat: fields[5].parse::<i64>()
+                mining_fee_sat: fields[5]
+                    .parse::<i64>()
                     .with_context(|| format!("invalid mining_fee_sat: {}", fields[5]))?,
-                service_fee_msat: fields[6].parse::<i64>()
+                service_fee_msat: fields[6]
+                    .parse::<i64>()
                     .with_context(|| format!("invalid service_fee_msat: {}", fields[6]))?,
                 payment_hash: fields[7].clone(),
                 tx_id: fields[8].clone(),
@@ -111,8 +119,8 @@ impl TransactionSource for PhoenixdCsv {
         for rec in &self.records {
             // Only accept types we have test coverage for.
             match rec.tx_type.as_str() {
-                "lightning_received" | "lightning_sent" | "swap_out"
-                | "channel_close" | "liquidity_purchase" => {}
+                "lightning_received" | "lightning_sent" | "swap_out" | "channel_close"
+                | "liquidity_purchase" => {}
                 other => bail!("unsupported phoenixd transaction type: {other}"),
             }
 
@@ -419,7 +427,10 @@ mod tests {
 
         assert_eq!(txs[7].category, TxCategory::Send);
         assert_eq!(txs[7].amount_sats, -41364); // 18364 mining + 23000 service
-        assert!(matches!(txs[7].kind, crate::import::TxKind::LiquidityPurchase { .. }));
+        assert!(matches!(
+            txs[7].kind,
+            crate::import::TxKind::LiquidityPurchase { .. }
+        ));
     }
 
     #[test]
@@ -457,8 +468,14 @@ mod tests {
         assert_eq!(txs[3].label, "channel_close");
         assert_eq!(txs[4].label, "lightning_sent");
 
-        assert_eq!(txs[0].payment_hash.as_deref(), Some("462f75bff2bd054c7d1f28f3524bc6c5e1022f36369d4e0a35324674fd2b6922"));
-        assert_eq!(txs[4].payment_hash.as_deref(), Some("f6ce6b8bb04a6639cb93d0ec5d3ed1eb33448e60ac91e82f90ff76fbe84f36e1"));
+        assert_eq!(
+            txs[0].payment_hash.as_deref(),
+            Some("462f75bff2bd054c7d1f28f3524bc6c5e1022f36369d4e0a35324674fd2b6922")
+        );
+        assert_eq!(
+            txs[4].payment_hash.as_deref(),
+            Some("f6ce6b8bb04a6639cb93d0ec5d3ed1eb33448e60ac91e82f90ff76fbe84f36e1")
+        );
         assert!(txs[1].payment_hash.is_none()); // swap_out has no payment hash
     }
 
@@ -466,16 +483,28 @@ mod tests {
     fn rejects_legacy_types() {
         let csv = "date,id,type,amount_msat,fee_credit_msat,mining_fee_sat,service_fee_msat,payment_hash,tx_id\n\
                    2024-01-01T00:00:00.000Z,a,legacy_pay_to_open,1000,0,0,0,abc,\n";
-        let err = PhoenixdCsv::from_str(csv).unwrap().list_transactions().expect_err("should reject legacy type");
-        assert!(err.to_string().contains("unsupported phoenixd transaction type: legacy_pay_to_open"));
+        let err = PhoenixdCsv::from_str(csv)
+            .unwrap()
+            .list_transactions()
+            .expect_err("should reject legacy type");
+        assert!(
+            err.to_string()
+                .contains("unsupported phoenixd transaction type: legacy_pay_to_open")
+        );
     }
 
     #[test]
     fn rejects_unknown_type() {
         let csv = "date,id,type,amount_msat,fee_credit_msat,mining_fee_sat,service_fee_msat,payment_hash,tx_id\n\
                    2024-01-01T00:00:00.000Z,a,fee_bumping,1000,0,0,0,,\n";
-        let err = PhoenixdCsv::from_str(csv).unwrap().list_transactions().expect_err("should reject unknown type");
-        assert!(err.to_string().contains("unsupported phoenixd transaction type: fee_bumping"));
+        let err = PhoenixdCsv::from_str(csv)
+            .unwrap()
+            .list_transactions()
+            .expect_err("should reject unknown type");
+        assert!(
+            err.to_string()
+                .contains("unsupported phoenixd transaction type: fee_bumping")
+        );
     }
 
     /// Receives accumulate fee credits, a channel opening consumes them, then a
@@ -508,12 +537,23 @@ date,id,type,amount_msat,fee_credit_msat,mining_fee_sat,service_fee_msat,payment
         // r1 → 503 sat (credit income)
         // r2 → 340_861 sat receive + 41_364 sat gross fee
         // s1 → −300_000 sat send
-        let balance: i64 = txs.iter().map(|tx| {
-            let fee = tx.fee_sats.unwrap_or(0).unsigned_abs() as i64;
-            tx.amount_sats - if tx.category == TxCategory::Send { fee } else { 0 }
-        }).sum();
+        let balance: i64 = txs
+            .iter()
+            .map(|tx| {
+                let fee = tx.fee_sats.unwrap_or(0).unsigned_abs() as i64;
+                tx.amount_sats
+                    - if tx.category == TxCategory::Send {
+                        fee
+                    } else {
+                        0
+                    }
+            })
+            .sum();
 
-        assert_eq!(balance, 0, "sat balance must be zero when the actual msat balance is zero");
+        assert_eq!(
+            balance, 0,
+            "sat balance must be zero when the actual msat balance is zero"
+        );
     }
 
     /// When a channel opening coincides with fee-credit consumption and a
@@ -550,7 +590,10 @@ date,id,type,amount_msat,fee_credit_msat,mining_fee_sat,service_fee_msat,payment
         // P2 fee: gross 22149 sat.
         assert_eq!(txs[2].amount_sats, -22149);
         assert_eq!(txs[2].category, TxCategory::Send);
-        assert!(matches!(txs[2].kind, crate::import::TxKind::LiquidityPurchase { .. }));
+        assert!(matches!(
+            txs[2].kind,
+            crate::import::TxKind::LiquidityPurchase { .. }
+        ));
 
         // P3: BTCPay shortfall payment 8410 sat.
         assert_eq!(txs[3].amount_sats, 8410);
@@ -558,10 +601,18 @@ date,id,type,amount_msat,fee_credit_msat,mining_fee_sat,service_fee_msat,payment
 
         // Total: 13739 + 12235 − 22149 + 8410 = 12235.
         assert_eq!(source.wallet_balance_sats(), 12235);
-        let balance: i64 = txs.iter().map(|tx| {
-            let fee = tx.fee_sats.unwrap_or(0).unsigned_abs() as i64;
-            tx.amount_sats - if tx.category == TxCategory::Send { fee } else { 0 }
-        }).sum();
+        let balance: i64 = txs
+            .iter()
+            .map(|tx| {
+                let fee = tx.fee_sats.unwrap_or(0).unsigned_abs() as i64;
+                tx.amount_sats
+                    - if tx.category == TxCategory::Send {
+                        fee
+                    } else {
+                        0
+                    }
+            })
+            .sum();
         assert_eq!(balance, 12235, "accounting must match wallet balance");
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -53,9 +53,10 @@ where
         cache_rates_cmd::SUBCOMMAND_NAME => Ok(Command::CacheRates(
             cache_rates_cmd::parse_args_from(args, cache_rates_cmd::USAGE)?,
         )),
-        export_cmd::SUBCOMMAND_NAME => Ok(Command::Export(
-            export_cmd::parse_args_from(args, export_cmd::USAGE)?,
-        )),
+        export_cmd::SUBCOMMAND_NAME => Ok(Command::Export(export_cmd::parse_args_from(
+            args,
+            export_cmd::USAGE,
+        )?)),
         reconstruct_cmd::SUBCOMMAND_NAME => Ok(Command::Reconstruct(
             reconstruct_cmd::parse_args_from(args, reconstruct_cmd::USAGE)?,
         )),
@@ -115,8 +116,8 @@ mod tests {
 
     #[test]
     fn parses_cache_rates_subcommand() {
-        let command = parse_command_from(vec!["cache-rates".to_owned(), "2024".to_owned()])
-            .expect("command");
+        let command =
+            parse_command_from(vec!["cache-rates".to_owned(), "2024".to_owned()]).expect("command");
 
         match command {
             Command::CacheRates(args) => {

--- a/tests/phoenixd.rs
+++ b/tests/phoenixd.rs
@@ -2,16 +2,15 @@ use std::path::Path;
 
 use anyhow::{Context, Result};
 use btc_fiat_value::accounting::{AccountingConfig, build_statement};
-use btc_fiat_value::export::camt053::Camt053Exporter;
 use btc_fiat_value::exchange_rate::ExchangeRateProvider;
+use btc_fiat_value::export::camt053::Camt053Exporter;
 use btc_fiat_value::iban::iban_from_node_id;
 use btc_fiat_value::import::TransactionSource;
 use btc_fiat_value::import::phoenixd_csv::PhoenixdCsv;
 
 /// ACINQ's public node ID — a real, publicly known Lightning node key used as
 /// a stable test input for deterministic IBAN and XML generation.
-const ACINQ_NODE_ID: &str =
-    "03864ef025fde8fb587d989186ce6a4a186895ee44a926bfc370e2c366597a3f8f";
+const ACINQ_NODE_ID: &str = "03864ef025fde8fb587d989186ce6a4a186895ee44a926bfc370e2c366597a3f8f";
 
 /// Daily real EUR/BTC rates for 2024 from tests/fixtures/rates_2024.json,
 /// indexed by day-of-year.  Extracted from Kraken XXBTZEUR 1440-minute candles.
@@ -21,8 +20,7 @@ struct RateProvider2024 {
 
 impl RateProvider2024 {
     fn load() -> Result<Self> {
-        let path = Path::new(env!("CARGO_MANIFEST_DIR"))
-            .join("tests/fixtures/rates_2024.json");
+        let path = Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/rates_2024.json");
         let data = std::fs::read_to_string(&path)
             .with_context(|| format!("failed to read {}", path.display()))?;
         let rates: Vec<f64> = serde_json::from_str(&data)?;
@@ -40,7 +38,10 @@ impl ExchangeRateProvider for RateProvider2024 {
             .unwrap()
             .and_utc();
         let day_index = (dt.signed_duration_since(start_of_2024).num_days()).max(0) as usize;
-        let rate = self.rates.get(day_index).copied()
+        let rate = self
+            .rates
+            .get(day_index)
+            .copied()
             .with_context(|| format!("no rate for day index {day_index}"))?;
         Ok(rate)
     }
@@ -51,8 +52,7 @@ impl ExchangeRateProvider for RateProvider2024 {
 /// invariants.  CI validates the committed file against the official XSD.
 #[test]
 fn phoenixd_csv_export_produces_valid_camt053() -> Result<()> {
-    let csv_path = Path::new(env!("CARGO_MANIFEST_DIR"))
-        .join("tests/fixtures/phoenixd_sample.csv");
+    let csv_path = Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/phoenixd_sample.csv");
     let csv = std::fs::read_to_string(&csv_path)?;
 
     let source = PhoenixdCsv::from_str(&csv)?;
@@ -86,8 +86,8 @@ fn phoenixd_csv_export_produces_valid_camt053() -> Result<()> {
     let xml = String::from_utf8(output)?;
 
     // Persist so CI can run xmllint over it.
-    let fixture_path = Path::new(env!("CARGO_MANIFEST_DIR"))
-        .join("tests/fixtures/phoenixd_sample_camt053.xml");
+    let fixture_path =
+        Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/phoenixd_sample_camt053.xml");
     std::fs::write(&fixture_path, &xml)?;
 
     // Structural assertions.
@@ -98,7 +98,10 @@ fn phoenixd_csv_export_produces_valid_camt053() -> Result<()> {
 
     let entry_count = xml.matches("<Ntry>").count();
     assert!(entry_count > 0, "expected at least one entry");
-    eprintln!("Generated {entry_count} entries; saved to {}", fixture_path.display());
+    eprintln!(
+        "Generated {entry_count} entries; saved to {}",
+        fixture_path.display()
+    );
 
     Ok(())
 }

--- a/tests/regtest/ipc_mining.rs
+++ b/tests/regtest/ipc_mining.rs
@@ -34,10 +34,7 @@ pub fn load_coinbase_cache(path: &Path) -> Result<HashMap<String, CoinbaseSoluti
 }
 
 /// Save coinbase solutions to the cache file, sorted by block height.
-pub fn save_coinbase_cache(
-    path: &Path,
-    cache: &HashMap<String, CoinbaseSolution>,
-) -> Result<()> {
+pub fn save_coinbase_cache(path: &Path, cache: &HashMap<String, CoinbaseSolution>) -> Result<()> {
     // Sort keys by height order: compare text/numeric segments naturally
     let mut entries: Vec<(&String, &CoinbaseSolution)> = cache.iter().collect();
     entries.sort_by(|(a, _), (b, _)| {
@@ -49,11 +46,15 @@ pub fn save_coinbase_cache(
             while i < bytes.len() {
                 if bytes[i].is_ascii_digit() {
                     let start = i;
-                    while i < bytes.len() && bytes[i].is_ascii_digit() { i += 1; }
+                    while i < bytes.len() && bytes[i].is_ascii_digit() {
+                        i += 1;
+                    }
                     result.push(Ok(s[start..i].parse::<u32>().unwrap_or(0)));
                 } else {
                     let start = i;
-                    while i < bytes.len() && !bytes[i].is_ascii_digit() { i += 1; }
+                    while i < bytes.len() && !bytes[i].is_ascii_digit() {
+                        i += 1;
+                    }
                     result.push(Err(&s[start..i]));
                 }
             }
@@ -68,7 +69,9 @@ pub fn save_coinbase_cache(
                 (Ok(_), Err(_)) => std::cmp::Ordering::Less,
                 (Err(_), Ok(_)) => std::cmp::Ordering::Greater,
             };
-            if ord != std::cmp::Ordering::Equal { return ord; }
+            if ord != std::cmp::Ordering::Equal {
+                return ord;
+            }
         }
         sa.len().cmp(&sb.len())
     });
@@ -80,7 +83,13 @@ pub fn save_coinbase_cache(
     for (i, (key, val)) in entries.iter().enumerate() {
         let val_json = serde_json::to_string(val)?;
         let comma = if i + 1 < entries.len() { "," } else { "" };
-        writeln!(buf, "  {}: {}{}", serde_json::to_string(key)?, val_json, comma)?;
+        writeln!(
+            buf,
+            "  {}: {}{}",
+            serde_json::to_string(key)?,
+            val_json,
+            comma
+        )?;
     }
     writeln!(buf, "}}")?;
     std::fs::write(path, &buf)
@@ -99,14 +108,12 @@ pub async fn mine_block_ipc(
     coinbase_output_script: &[u8],
     cached: Option<&CoinbaseSolution>,
 ) -> Result<CoinbaseSolution> {
-    let stream = UnixStream::connect(socket_path)
-        .await
-        .with_context(|| {
-            format!(
-                "IPC connection to {} failed. Is bitcoin running with -ipcbind=unix?",
-                socket_path.display()
-            )
-        })?;
+    let stream = UnixStream::connect(socket_path).await.with_context(|| {
+        format!(
+            "IPC connection to {} failed. Is bitcoin running with -ipcbind=unix?",
+            socket_path.display()
+        )
+    })?;
 
     let (reader, writer) = stream.into_split();
     let buf_reader = BufReader::new(reader.compat());
@@ -124,11 +131,7 @@ pub async fn mine_block_ipc(
         .promise
         .await
         .context("IPC construct failed")?;
-    let thread_map = construct_resp
-        .get()
-        .unwrap()
-        .get_thread_map()
-        .unwrap();
+    let thread_map = construct_resp.get().unwrap().get_thread_map().unwrap();
     let thread_resp = thread_map
         .make_thread_request()
         .send()
@@ -195,8 +198,7 @@ pub async fn mine_block_ipc(
 
     // Build coinbase transaction
     let coinbase_tx = if let Some(cached) = cached {
-        hex::decode(&cached.coinbase_hex)
-            .context("failed to decode cached coinbase hex")?
+        hex::decode(&cached.coinbase_hex).context("failed to decode cached coinbase hex")?
     } else {
         build_coinbase_tx(
             cb_version,
@@ -216,10 +218,7 @@ pub async fn mine_block_ipc(
     if let Some(cached) = cached {
         // Use cached solution directly
         let mut req = template.submit_solution_request();
-        req.get()
-            .get_context()
-            .unwrap()
-            .set_thread(thread.clone());
+        req.get().get_context().unwrap().set_thread(thread.clone());
         req.get().set_version(cached.version);
         req.get().set_timestamp(cached.timestamp);
         req.get().set_nonce(cached.nonce);
@@ -245,10 +244,7 @@ pub async fn mine_block_ipc(
     // Brute-force nonce
     for nonce in 0..u32::MAX {
         let mut req = template.submit_solution_request();
-        req.get()
-            .get_context()
-            .unwrap()
-            .set_thread(thread.clone());
+        req.get().get_context().unwrap().set_thread(thread.clone());
         req.get().set_version(version);
         req.get().set_timestamp(timestamp);
         req.get().set_nonce(nonce);

--- a/tests/regtest/main.rs
+++ b/tests/regtest/main.rs
@@ -3,9 +3,12 @@ mod node;
 mod wallet;
 
 use anyhow::{Context, Result};
+use btc_fiat_value::import::{TransactionSource, TxCategory, TxKind, WalletTransaction};
 use rand::Rng;
 use rand::SeedableRng;
 use rand::rngs::StdRng;
+use std::path::Path;
+use std::process::Command;
 
 use ipc_mining::{load_coinbase_cache, save_coinbase_cache};
 use node::RegtestNode;
@@ -61,7 +64,7 @@ fn run_salary_scenario() -> Result<()> {
         .and_utc()
         .timestamp();
 
-    let node = RegtestNode::start(&bitcoin_path, initial_time)?;
+    let mut node = RegtestNode::start(&bitcoin_path, initial_time)?;
     eprintln!("Started regtest node on port {}", node.rpc_port());
 
     // Create deterministic wallets with fixed tprv keys
@@ -194,7 +197,9 @@ fn run_salary_scenario() -> Result<()> {
     let descriptors = accounting.get_receive_descriptors(&receive_addresses)?;
     eprintln!("Found {} receive descriptor(s)", descriptors.len());
 
-    let mock_provider = MockRateProvider { rates: mock_rates };
+    let mock_provider = MockRateProvider {
+        rates: mock_rates.clone(),
+    };
     let iban = btc_fiat_value::iban::iban_from_fingerprint(&fingerprint, "NL", "regtest")?;
     eprintln!("Generated IBAN: {iban}");
 
@@ -297,7 +302,106 @@ fn run_salary_scenario() -> Result<()> {
     // Roundtrip: create watch-only wallet from embedded descriptors, verify all txs match
     verify_roundtrip(&xml, &node)?;
 
+    let bitcoin_wallet_path = node::find_bitcoin_wallet(&bitcoin_path)?;
+    let labels_path = node.datadir().join("accounting-bip329.jsonl");
+    node.stop()?;
+
+    export_bitcoin_core_bip329(
+        &bitcoin_wallet_path,
+        node.datadir(),
+        "accounting",
+        &labels_path,
+    )?;
+    let bip329_source =
+        btc_fiat_value::import::bitcoin_core_bip329::BitcoinCoreBip329::from_path(&labels_path)?;
+    eprintln!(
+        "Exported Bitcoin Core BIP329 JSONL with {} descriptor(s)",
+        bip329_source.descriptors().len()
+    );
+
+    assert_eq!(
+        bip329_source.fingerprint(),
+        fingerprint,
+        "BIP329 export fingerprint should match RPC descriptor fingerprint"
+    );
+
+    let bip329_transactions = bip329_source.list_transactions()?;
+    assert_wallet_transactions_equivalent(&transactions, &bip329_transactions);
+
+    let bip329_provider = MockRateProvider {
+        rates: mock_rates.clone(),
+    };
+    let mut bip329_statement = btc_fiat_value::accounting::build_statement(
+        &bip329_transactions,
+        &bip329_provider,
+        &config,
+    )?;
+    bip329_statement.descriptors = bip329_source.descriptors().to_vec();
+    assert!(
+        !bip329_statement.descriptors.is_empty(),
+        "BIP329 export should include descriptors"
+    );
+    assert_statement_accounting_equivalent(&statement, &bip329_statement);
+
     eprintln!("\n✅ Salary scenario passed");
+    Ok(())
+}
+
+fn export_bitcoin_core_bip329(
+    bitcoin_wallet_path: &Path,
+    datadir: &Path,
+    wallet_name: &str,
+    labels_path: &Path,
+) -> Result<()> {
+    let output = Command::new(bitcoin_wallet_path)
+        .arg(format!("-datadir={}", datadir.display()))
+        .arg("-chain=regtest")
+        .arg(format!("-wallet={wallet_name}"))
+        .arg(format!("-labelsfile={}", labels_path.display()))
+        .arg("exportlabels")
+        .output()
+        .with_context(|| {
+            format!(
+                "failed to run Bitcoin Core BIP329 export with {}",
+                bitcoin_wallet_path.display()
+            )
+        })?;
+
+    if !output.status.success() {
+        anyhow::bail!(
+            "bitcoin-wallet exportlabels failed with status {}\nstdout:\n{}\nstderr:\n{}",
+            output.status,
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    let exported = std::fs::read_to_string(labels_path)
+        .with_context(|| format!("failed to read {}", labels_path.display()))?;
+    assert!(
+        exported
+            .lines()
+            .any(|line| line.contains("\"type\":\"tx\"")),
+        "BIP329 export should include transaction records"
+    );
+    assert!(
+        exported
+            .lines()
+            .any(|line| line.contains("\"type\":\"output\"")),
+        "BIP329 export should include output records"
+    );
+    assert!(
+        exported
+            .lines()
+            .any(|line| line.contains("\"type\":\"descriptor\"")),
+        "BIP329 export should include descriptor records"
+    );
+
+    eprintln!(
+        "  Exported {} BIP329 record(s) to {}",
+        exported.lines().count(),
+        labels_path.display()
+    );
     Ok(())
 }
 
@@ -414,6 +518,160 @@ fn verify_roundtrip(xml: &str, node: &RegtestNode) -> Result<()> {
 
     eprintln!("  ✅ Roundtrip verified: {verified} transactions match");
     Ok(())
+}
+
+fn assert_wallet_transactions_equivalent(
+    rpc_transactions: &[WalletTransaction],
+    bip329_transactions: &[WalletTransaction],
+) {
+    let mut rpc: Vec<_> = rpc_transactions
+        .iter()
+        .map(comparable_wallet_transaction)
+        .collect();
+    let mut bip329: Vec<_> = bip329_transactions
+        .iter()
+        .map(comparable_wallet_transaction)
+        .collect();
+
+    rpc.sort();
+    bip329.sort();
+
+    assert_eq!(
+        rpc, bip329,
+        "Bitcoin Core RPC and BIP329 export should describe the same wallet transactions"
+    );
+    eprintln!(
+        "  BIP329 transaction equivalence verified: {} transaction(s)",
+        bip329.len()
+    );
+}
+
+#[derive(Debug, Eq, Ord, PartialEq, PartialOrd)]
+struct ComparableWalletTransaction {
+    txid: String,
+    vout: u32,
+    amount_sats: i64,
+    fee_sats_abs: Option<i64>,
+    category: &'static str,
+    booking_date: String,
+    block_hash: String,
+    address: String,
+    label: String,
+    kind: &'static str,
+}
+
+fn comparable_wallet_transaction(tx: &WalletTransaction) -> ComparableWalletTransaction {
+    ComparableWalletTransaction {
+        txid: tx.txid.clone(),
+        vout: tx.vout,
+        amount_sats: tx.amount_sats,
+        fee_sats_abs: tx.fee_sats.map(|fee| fee.unsigned_abs() as i64),
+        category: match &tx.category {
+            TxCategory::Send => "send",
+            TxCategory::Receive => "receive",
+        },
+        // The offline wallet export currently provides wallet transaction time
+        // and may omit block height. For this daily accounting scenario, the
+        // stable cross-source key is the booking date plus full blockhash ref.
+        booking_date: timestamp_date(tx.block_time),
+        block_hash: tx.block_hash.clone(),
+        address: tx.address.clone(),
+        label: tx.label.clone(),
+        kind: match &tx.kind {
+            TxKind::Default => "default",
+            TxKind::LiquidityPurchase { .. } => "liquidity_purchase",
+        },
+    }
+}
+
+fn assert_statement_accounting_equivalent(
+    rpc_statement: &btc_fiat_value::export::Statement,
+    bip329_statement: &btc_fiat_value::export::Statement,
+) {
+    assert_eq!(
+        comparable_statement(rpc_statement),
+        comparable_statement(bip329_statement),
+        "Bitcoin Core RPC and BIP329 export should produce equivalent accounting statements"
+    );
+    eprintln!(
+        "  BIP329 accounting equivalence verified: {} statement entry/entries",
+        bip329_statement.entries.len()
+    );
+}
+
+#[derive(Debug, Eq, PartialEq)]
+struct ComparableStatement {
+    account_iban: String,
+    currency: String,
+    opening_balance_cents: i64,
+    opening_balance_sats: i64,
+    opening_rate_cents: Option<i64>,
+    entries: Vec<ComparableEntry>,
+    closing_balance_cents: i64,
+    closing_balance_sats: i64,
+    opening_date: String,
+    statement_date: String,
+    statement_id: String,
+    bank_name: Option<String>,
+}
+
+#[derive(Debug, Eq, PartialEq)]
+struct ComparableEntry {
+    full_ref: String,
+    booking_date: String,
+    amount_cents: i64,
+    is_credit: bool,
+    description: String,
+    is_fee: bool,
+}
+
+fn comparable_statement(statement: &btc_fiat_value::export::Statement) -> ComparableStatement {
+    ComparableStatement {
+        account_iban: statement.account_iban.clone(),
+        currency: statement.currency.clone(),
+        opening_balance_cents: statement.opening_balance_cents,
+        opening_balance_sats: statement.opening_balance_sats,
+        opening_rate_cents: statement
+            .opening_rate
+            .map(|rate| (rate * 100.0).round() as i64),
+        entries: statement.entries.iter().map(comparable_entry).collect(),
+        closing_balance_cents: statement.closing_balance_cents,
+        closing_balance_sats: statement.closing_balance_sats,
+        opening_date: statement.opening_date.clone(),
+        statement_date: statement.statement_date.clone(),
+        statement_id: statement.statement_id.clone(),
+        bank_name: statement.bank_name.clone(),
+    }
+}
+
+fn comparable_entry(entry: &btc_fiat_value::export::Entry) -> ComparableEntry {
+    ComparableEntry {
+        // Short refs and FIFO refs include block height; the current offline
+        // export does not reliably provide it, while full on-chain refs do.
+        full_ref: comparable_full_ref(&entry.full_ref),
+        booking_date: entry.booking_date.clone(),
+        amount_cents: entry.amount_cents,
+        is_credit: entry.is_credit,
+        description: entry.description.clone(),
+        is_fee: entry.is_fee,
+    }
+}
+
+fn comparable_full_ref(full_ref: &str) -> String {
+    if let Some(rest) = full_ref.strip_prefix(":fifo:") {
+        if let Some((_, suffix)) = rest.split_once(':') {
+            return format!(":fifo:<height>:{suffix}");
+        }
+    }
+    full_ref.to_owned()
+}
+
+fn timestamp_date(timestamp: i64) -> String {
+    chrono::DateTime::<chrono::Utc>::from_timestamp(timestamp, 0)
+        .expect("valid timestamp")
+        .date_naive()
+        .format("%Y-%m-%d")
+        .to_string()
 }
 
 fn skip_to_workday(date: chrono::NaiveDate) -> chrono::NaiveDate {

--- a/tests/regtest/main.rs
+++ b/tests/regtest/main.rs
@@ -4,8 +4,8 @@ mod wallet;
 
 use anyhow::{Context, Result};
 use rand::Rng;
-use rand::rngs::StdRng;
 use rand::SeedableRng;
+use rand::rngs::StdRng;
 
 use ipc_mining::{load_coinbase_cache, save_coinbase_cache};
 use node::RegtestNode;
@@ -71,7 +71,8 @@ fn run_salary_scenario() -> Result<()> {
 
     // Generate initial blocks for maturity (100-block coinbase maturity + 1)
     let mining_addr = mining.get_new_address()?;
-    let all_cached = mining.mine_blocks_ipc(101, &mining_addr, "maturity-", &mut coinbase_cache, &rt)?;
+    let all_cached =
+        mining.mine_blocks_ipc(101, &mining_addr, "maturity-", &mut coinbase_cache, &rt)?;
     if !all_cached {
         eprintln!("⚠️  Cache miss during maturity blocks — output may not be deterministic");
     }
@@ -121,13 +122,14 @@ fn run_salary_scenario() -> Result<()> {
         }
         mining.send_to_address(&accounting_addr, salary_sats)?;
         let label = format!("salary-{month}-");
-        let all_cached = mining.mine_blocks_ipc(1, &mining_addr, &label, &mut coinbase_cache, &rt)?;
+        let all_cached =
+            mining.mine_blocks_ipc(1, &mining_addr, &label, &mut coinbase_cache, &rt)?;
         if !all_cached {
-            eprintln!("⚠️  Cache miss at month {month} salary block — output may not be deterministic");
+            eprintln!(
+                "⚠️  Cache miss at month {month} salary block — output may not be deterministic"
+            );
         }
-        eprintln!(
-            "Month {month}: Received {salary_sats} sats (€5,000 at rate {rate:.2})"
-        );
+        eprintln!("Month {month}: Received {salary_sats} sats (€5,000 at rate {rate:.2})");
 
         // Random delay before spending (0-5 days), during daytime CET (14:00-20:00 CET = 13:00-19:00 UTC)
         let delay_days: i64 = rng.random_range(0..=5);
@@ -151,9 +153,12 @@ fn run_salary_scenario() -> Result<()> {
             }
             accounting.send_to_address(&mining_addr_spend, spend_sats)?;
             let label = format!("spend-{month}-");
-            let all_cached = mining.mine_blocks_ipc(1, &mining_addr, &label, &mut coinbase_cache, &rt)?;
+            let all_cached =
+                mining.mine_blocks_ipc(1, &mining_addr, &label, &mut coinbase_cache, &rt)?;
             if !all_cached {
-                eprintln!("⚠️  Cache miss at month {month} spend block — output may not be deterministic");
+                eprintln!(
+                    "⚠️  Cache miss at month {month} spend block — output may not be deterministic"
+                );
             }
             eprintln!(
                 "  Spent {spend_sats} sats ({:.0}%) after {delay_days} day(s)",
@@ -181,7 +186,8 @@ fn run_salary_scenario() -> Result<()> {
     eprintln!("Listed {} transactions", transactions.len());
 
     // Collect receive addresses and fetch matching watch-only descriptors
-    let receive_addresses: std::collections::HashSet<String> = transactions.iter()
+    let receive_addresses: std::collections::HashSet<String> = transactions
+        .iter()
         .filter(|tx| tx.category == btc_fiat_value::import::TxCategory::Receive)
         .map(|tx| tx.address.clone())
         .collect();
@@ -207,7 +213,8 @@ fn run_salary_scenario() -> Result<()> {
         fee_threshold_cents: 1,
     };
 
-    let mut statement = btc_fiat_value::accounting::build_statement(&transactions, &mock_provider, &config)?;
+    let mut statement =
+        btc_fiat_value::accounting::build_statement(&transactions, &mock_provider, &config)?;
     statement.descriptors = descriptors;
 
     // Write CAMT.053 output
@@ -238,22 +245,43 @@ fn run_salary_scenario() -> Result<()> {
     assert!(entry_count > 0, "expected at least one entry");
 
     // Verify mark-to-market entry exists
-    assert!(xml.contains(":mtm:2025-12-31"), "expected mark-to-market entry");
+    assert!(
+        xml.contains(":mtm:2025-12-31"),
+        "expected mark-to-market entry"
+    );
 
     // Verify watch-only descriptors are included as comments
-    assert!(xml.contains("Watch-only descriptors"), "expected descriptor comments");
+    assert!(
+        xml.contains("Watch-only descriptors"),
+        "expected descriptor comments"
+    );
     assert!(xml.contains("tpub"), "expected tpub in descriptor comments");
 
     // Verify BTC opening balance comment includes rate, and sanity-check the fiat value
-    let balance_comment = xml.lines()
+    let balance_comment = xml
+        .lines()
         .find(|l| l.contains("BTC opening balance"))
         .expect("expected BTC opening balance comment");
-    assert!(balance_comment.contains(" @ "), "expected rate in BTC opening balance comment");
+    assert!(
+        balance_comment.contains(" @ "),
+        "expected rate in BTC opening balance comment"
+    );
     // Parse: "<!-- BTC opening balance: 0.00100000 BTC @ 95277.13 -->"
     let after_colon = balance_comment.split(':').last().unwrap().trim();
     let parts: Vec<&str> = after_colon.split(" @ ").collect();
-    let btc: f64 = parts[0].trim().split_whitespace().next().unwrap().parse().unwrap();
-    let rate: f64 = parts[1].trim().trim_end_matches("-->").trim().parse().unwrap();
+    let btc: f64 = parts[0]
+        .trim()
+        .split_whitespace()
+        .next()
+        .unwrap()
+        .parse()
+        .unwrap();
+    let rate: f64 = parts[1]
+        .trim()
+        .trim_end_matches("-->")
+        .trim()
+        .parse()
+        .unwrap();
     let fiat_from_comment = btc * rate;
     let opening_cents = statement.opening_balance_cents;
     let opening_fiat = opening_cents as f64 / 100.0;
@@ -278,7 +306,10 @@ fn verify_reconstruction(xml: &str, node: &RegtestNode) -> Result<()> {
     let mut count = 0;
     for line in xml.lines() {
         let line = line.trim();
-        if let Some(content) = line.strip_prefix("<AddtlNtryInf>").and_then(|s| s.strip_suffix("</AddtlNtryInf>")) {
+        if let Some(content) = line
+            .strip_prefix("<AddtlNtryInf>")
+            .and_then(|s| s.strip_suffix("</AddtlNtryInf>"))
+        {
             // Skip virtual entries (prefixed with :)
             if content.starts_with(':') {
                 continue;
@@ -286,7 +317,11 @@ fn verify_reconstruction(xml: &str, node: &RegtestNode) -> Result<()> {
 
             // Format: blockhash:txid:vout
             let parts: Vec<&str> = content.split(':').collect();
-            assert_eq!(parts.len(), 3, "expected blockhash:txid:vout, got: {content}");
+            assert_eq!(
+                parts.len(),
+                3,
+                "expected blockhash:txid:vout, got: {content}"
+            );
 
             let blockhash = parts[0];
             let txid = parts[1];
@@ -297,13 +332,9 @@ fn verify_reconstruction(xml: &str, node: &RegtestNode) -> Result<()> {
                 &[serde_json::json!(blockhash), serde_json::json!(1)],
             )?;
 
-            let block_txids = block["tx"]
-                .as_array()
-                .context("block has no tx array")?;
+            let block_txids = block["tx"].as_array().context("block has no tx array")?;
 
-            let found = block_txids
-                .iter()
-                .any(|t| t.as_str() == Some(txid));
+            let found = block_txids.iter().any(|t| t.as_str() == Some(txid));
 
             assert!(found, "txid {txid} not found in block {blockhash}");
             count += 1;
@@ -318,9 +349,15 @@ fn verify_reconstruction(xml: &str, node: &RegtestNode) -> Result<()> {
 fn verify_roundtrip(xml: &str, node: &RegtestNode) -> Result<()> {
     // Parse descriptors from XML comments
     let parsed = btc_fiat_value::export::camt053::parse_camt053(xml)?;
-    assert!(!parsed.descriptors.is_empty(), "expected descriptors in XML");
+    assert!(
+        !parsed.descriptors.is_empty(),
+        "expected descriptors in XML"
+    );
 
-    eprintln!("\nRoundtrip: creating watch-only wallet from {} descriptor(s)...", parsed.descriptors.len());
+    eprintln!(
+        "\nRoundtrip: creating watch-only wallet from {} descriptor(s)...",
+        parsed.descriptors.len()
+    );
 
     // Create watch-only wallet and import descriptors
     let watch_only = RpcWallet::create_watch_only(node, "roundtrip", &parsed.descriptors)?;
@@ -328,10 +365,14 @@ fn verify_roundtrip(xml: &str, node: &RegtestNode) -> Result<()> {
 
     // List transactions from the reconstructed wallet
     let wallet_txs = watch_only.list_transactions()?;
-    eprintln!("  Found {} transactions in watch-only wallet", wallet_txs.len());
+    eprintln!(
+        "  Found {} transactions in watch-only wallet",
+        wallet_txs.len()
+    );
 
     // Build lookup set of txid:vout from the wallet
-    let wallet_tx_set: std::collections::HashSet<String> = wallet_txs.iter()
+    let wallet_tx_set: std::collections::HashSet<String> = wallet_txs
+        .iter()
         .map(|tx| format!("{}:{}", tx.txid, tx.vout))
         .collect();
 
@@ -365,7 +406,10 @@ fn verify_roundtrip(xml: &str, node: &RegtestNode) -> Result<()> {
         for ref_id in &missing {
             eprintln!("  Missing: {ref_id}");
         }
-        anyhow::bail!("{} transaction(s) from XML not found in watch-only wallet", missing.len());
+        anyhow::bail!(
+            "{} transaction(s) from XML not found in watch-only wallet",
+            missing.len()
+        );
     }
 
     eprintln!("  ✅ Roundtrip verified: {verified} transactions match");
@@ -383,9 +427,18 @@ fn skip_to_workday(date: chrono::NaiveDate) -> chrono::NaiveDate {
 
 fn month_name(month: usize) -> &'static str {
     match month {
-        1 => "January", 2 => "February", 3 => "March", 4 => "April",
-        5 => "May", 6 => "June", 7 => "July", 8 => "August",
-        9 => "September", 10 => "October", 11 => "November", 12 => "December",
+        1 => "January",
+        2 => "February",
+        3 => "March",
+        4 => "April",
+        5 => "May",
+        6 => "June",
+        7 => "July",
+        8 => "August",
+        9 => "September",
+        10 => "October",
+        11 => "November",
+        12 => "December",
         _ => "Unknown",
     }
 }

--- a/tests/regtest/node.rs
+++ b/tests/regtest/node.rs
@@ -110,6 +110,15 @@ impl RegtestNode {
         self.datadir.path()
     }
 
+    pub fn stop(&mut self) -> Result<()> {
+        if let Some(mut child) = self.process.take() {
+            // Try graceful shutdown via RPC stop.
+            let _ = self.rpc_call::<serde_json::Value>("stop", &[]);
+            child.wait().context("failed to wait for bitcoin node")?;
+        }
+        Ok(())
+    }
+
     /// Path to the IPC Unix socket (created by -ipcbind=unix).
     pub fn ipc_socket_path(&self) -> PathBuf {
         self.datadir.path().join("regtest").join("node.sock")
@@ -215,5 +224,25 @@ pub fn find_bitcoin() -> Result<PathBuf> {
          cmake -B build -DENABLE_WALLET=ON -DBUILD_TESTS=OFF -DBUILD_BENCH=OFF\n  \
          cmake --build build -j$(nproc) --target bitcoin bitcoin-node",
         bitcoin.display()
+    );
+}
+
+/// Find the `bitcoin-wallet` binary next to the pre-built `bitcoin` wrapper.
+pub fn find_bitcoin_wallet(bitcoin_path: &Path) -> Result<PathBuf> {
+    let bitcoin_wallet = bitcoin_path
+        .parent()
+        .context("bitcoin path has no parent directory")?
+        .join("bitcoin-wallet");
+
+    if bitcoin_wallet.exists() {
+        return Ok(bitcoin_wallet);
+    }
+
+    bail!(
+        "bitcoin-wallet not found at {}.\n\
+         Build it first:\n  \
+         cd bitcoin-core\n  \
+         cmake --build build -j$(nproc) --target bitcoin-wallet",
+        bitcoin_wallet.display()
     );
 }

--- a/tests/regtest/node.rs
+++ b/tests/regtest/node.rs
@@ -162,11 +162,17 @@ impl RegtestNode {
 
         if let Some(err) = raw.get("error").filter(|e| !e.is_null()) {
             let code = err.get("code").and_then(|c| c.as_i64()).unwrap_or(-1);
-            let message = err.get("message").and_then(|m| m.as_str()).unwrap_or("unknown error");
+            let message = err
+                .get("message")
+                .and_then(|m| m.as_str())
+                .unwrap_or("unknown error");
             bail!("{method}: {message} (code {code})");
         }
 
-        let result_val = raw.get("result").cloned().unwrap_or(serde_json::Value::Null);
+        let result_val = raw
+            .get("result")
+            .cloned()
+            .unwrap_or(serde_json::Value::Null);
         serde_json::from_value(result_val)
             .with_context(|| format!("failed to decode {method} result"))
     }

--- a/tests/regtest/wallet.rs
+++ b/tests/regtest/wallet.rs
@@ -33,45 +33,56 @@ impl<'a> RpcWallet<'a> {
         let receive_desc = format!("wpkh({tprv}/84h/1h/0h/0/*)");
         let change_desc = format!("wpkh({tprv}/84h/1h/0h/1/*)");
 
-        let recv_info: serde_json::Value = node.rpc_call("getdescriptorinfo", &[serde_json::json!(receive_desc)])?;
-        let change_info: serde_json::Value = node.rpc_call("getdescriptorinfo", &[serde_json::json!(change_desc)])?;
+        let recv_info: serde_json::Value =
+            node.rpc_call("getdescriptorinfo", &[serde_json::json!(receive_desc)])?;
+        let change_info: serde_json::Value =
+            node.rpc_call("getdescriptorinfo", &[serde_json::json!(change_desc)])?;
 
-        let recv_checksum = recv_info["checksum"].as_str()
+        let recv_checksum = recv_info["checksum"]
+            .as_str()
             .context("getdescriptorinfo missing checksum for receive")?;
-        let change_checksum = change_info["checksum"].as_str()
+        let change_checksum = change_info["checksum"]
+            .as_str()
             .context("getdescriptorinfo missing checksum for change")?;
 
         let recv_desc_with_checksum = format!("{receive_desc}#{recv_checksum}");
         let change_desc_with_checksum = format!("{change_desc}#{change_checksum}");
 
-        wallet.wallet_call::<serde_json::Value>("importdescriptors", &[serde_json::json!([
-            {
-                "desc": recv_desc_with_checksum,
-                "timestamp": 0,
-                "active": true,
-                "keypool": true,
-                "internal": false,
-            },
-            {
-                "desc": change_desc_with_checksum,
-                "timestamp": 0,
-                "active": true,
-                "keypool": true,
-                "internal": true,
-            },
-        ])])?;
+        wallet.wallet_call::<serde_json::Value>(
+            "importdescriptors",
+            &[serde_json::json!([
+                {
+                    "desc": recv_desc_with_checksum,
+                    "timestamp": 0,
+                    "active": true,
+                    "keypool": true,
+                    "internal": false,
+                },
+                {
+                    "desc": change_desc_with_checksum,
+                    "timestamp": 0,
+                    "active": true,
+                    "keypool": true,
+                    "internal": true,
+                },
+            ])],
+        )?;
 
         Ok(wallet)
     }
 
     /// Create a watch-only wallet from multipath descriptors (for roundtrip testing).
-    pub fn create_watch_only(node: &'a RegtestNode, name: &str, descriptors: &[String]) -> Result<Self> {
+    pub fn create_watch_only(
+        node: &'a RegtestNode,
+        name: &str,
+        descriptors: &[String],
+    ) -> Result<Self> {
         node.rpc_call::<serde_json::Value>(
             "createwallet",
             &[
                 serde_json::json!(name),
-                serde_json::json!(true),  // disable_private_keys
-                serde_json::json!(true),  // blank
+                serde_json::json!(true), // disable_private_keys
+                serde_json::json!(true), // blank
             ],
         )?;
 
@@ -87,12 +98,16 @@ impl<'a> RpcWallet<'a> {
                 let recv = desc.replace("<0;1>", "0");
                 let change = desc.replace("<0;1>", "1");
 
-                let recv_info: serde_json::Value = node.rpc_call("getdescriptorinfo", &[serde_json::json!(recv)])?;
-                let change_info: serde_json::Value = node.rpc_call("getdescriptorinfo", &[serde_json::json!(change)])?;
+                let recv_info: serde_json::Value =
+                    node.rpc_call("getdescriptorinfo", &[serde_json::json!(recv)])?;
+                let change_info: serde_json::Value =
+                    node.rpc_call("getdescriptorinfo", &[serde_json::json!(change)])?;
 
-                let recv_with_checksum = recv_info["descriptor"].as_str()
+                let recv_with_checksum = recv_info["descriptor"]
+                    .as_str()
                     .context("getdescriptorinfo missing descriptor")?;
-                let change_with_checksum = change_info["descriptor"].as_str()
+                let change_with_checksum = change_info["descriptor"]
+                    .as_str()
                     .context("getdescriptorinfo missing descriptor")?;
 
                 import_descs.push(serde_json::json!({
@@ -112,8 +127,10 @@ impl<'a> RpcWallet<'a> {
                     "internal": true,
                 }));
             } else {
-                let info: serde_json::Value = node.rpc_call("getdescriptorinfo", &[serde_json::json!(desc)])?;
-                let desc_with_checksum = info["descriptor"].as_str()
+                let info: serde_json::Value =
+                    node.rpc_call("getdescriptorinfo", &[serde_json::json!(desc)])?;
+                let desc_with_checksum = info["descriptor"]
+                    .as_str()
                     .context("getdescriptorinfo missing descriptor")?;
 
                 import_descs.push(serde_json::json!({
@@ -127,29 +144,33 @@ impl<'a> RpcWallet<'a> {
             }
         }
 
-        wallet.wallet_call::<serde_json::Value>("importdescriptors", &[serde_json::json!(import_descs)])?;
+        wallet.wallet_call::<serde_json::Value>(
+            "importdescriptors",
+            &[serde_json::json!(import_descs)],
+        )?;
 
         Ok(wallet)
     }
 
     pub fn get_new_address(&self) -> Result<String> {
-        self.wallet_call("getnewaddress", &[
-            serde_json::json!(""),       // label
-            serde_json::json!("bech32"), // address_type
-        ])
+        self.wallet_call(
+            "getnewaddress",
+            &[
+                serde_json::json!(""),       // label
+                serde_json::json!("bech32"), // address_type
+            ],
+        )
     }
 
     fn get_change_address(&self) -> Result<String> {
-        self.wallet_call("getrawchangeaddress", &[
-            serde_json::json!("bech32"),
-        ])
+        self.wallet_call("getrawchangeaddress", &[serde_json::json!("bech32")])
     }
 
     pub fn set_label(&self, address: &str, label: &str) -> Result<()> {
-        self.wallet_call::<serde_json::Value>("setlabel", &[
-            serde_json::json!(address),
-            serde_json::json!(label),
-        ])?;
+        self.wallet_call::<serde_json::Value>(
+            "setlabel",
+            &[serde_json::json!(address), serde_json::json!(label)],
+        )?;
         Ok(())
     }
 
@@ -164,7 +185,10 @@ impl<'a> RpcWallet<'a> {
             let ta = a["txid"].as_str().unwrap_or("");
             let tb = b["txid"].as_str().unwrap_or("");
             ta.cmp(tb).then_with(|| {
-                a["vout"].as_u64().unwrap_or(0).cmp(&b["vout"].as_u64().unwrap_or(0))
+                a["vout"]
+                    .as_u64()
+                    .unwrap_or(0)
+                    .cmp(&b["vout"].as_u64().unwrap_or(0))
             })
         });
 
@@ -190,12 +214,15 @@ impl<'a> RpcWallet<'a> {
         let change = total_in - amount_sats - fee;
 
         // Build inputs and outputs in deterministic order: change at position 0
-        let inputs: Vec<serde_json::Value> = selected.iter().map(|u| {
-            serde_json::json!({
-                "txid": u["txid"],
-                "vout": u["vout"],
+        let inputs: Vec<serde_json::Value> = selected
+            .iter()
+            .map(|u| {
+                serde_json::json!({
+                    "txid": u["txid"],
+                    "vout": u["vout"],
+                })
             })
-        }).collect();
+            .collect();
 
         let change_addr = self.get_change_address()?;
         let outputs = if change > 0 {
@@ -208,16 +235,18 @@ impl<'a> RpcWallet<'a> {
         };
 
         // createrawtransaction preserves input ordering
-        let raw_hex: String = self.wallet_call("createrawtransaction", &[
-            serde_json::json!(inputs),
-            outputs,
-        ])?;
+        let raw_hex: String = self.wallet_call(
+            "createrawtransaction",
+            &[serde_json::json!(inputs), outputs],
+        )?;
 
         // Sign (ECDSA with RFC 6979 is deterministic)
-        let signed: serde_json::Value = self.wallet_call("signrawtransactionwithwallet", &[
-            serde_json::json!(raw_hex),
-        ])?;
-        let signed_hex = signed["hex"].as_str()
+        let signed: serde_json::Value = self.wallet_call(
+            "signrawtransactionwithwallet",
+            &[serde_json::json!(raw_hex)],
+        )?;
+        let signed_hex = signed["hex"]
+            .as_str()
             .context("signrawtransactionwithwallet missing hex")?;
         anyhow::ensure!(
             signed["complete"].as_bool() == Some(true),
@@ -225,9 +254,8 @@ impl<'a> RpcWallet<'a> {
         );
 
         // Send
-        let txid: String = self.wallet_call("sendrawtransaction", &[
-            serde_json::json!(signed_hex),
-        ])?;
+        let txid: String =
+            self.wallet_call("sendrawtransaction", &[serde_json::json!(signed_hex)])?;
         Ok(txid)
     }
 
@@ -245,10 +273,8 @@ impl<'a> RpcWallet<'a> {
         rt: &tokio::runtime::Runtime,
     ) -> Result<bool> {
         // Get scriptPubKey for the address
-        let addr_info: serde_json::Value = self.wallet_call(
-            "getaddressinfo",
-            &[serde_json::json!(address)],
-        )?;
+        let addr_info: serde_json::Value =
+            self.wallet_call("getaddressinfo", &[serde_json::json!(address)])?;
         let script_hex = addr_info["scriptPubKey"]
             .as_str()
             .context("getaddressinfo missing scriptPubKey")?;
@@ -265,12 +291,18 @@ impl<'a> RpcWallet<'a> {
                 all_cached = false;
             }
 
-            let solution = rt.block_on(async {
-                let local = tokio::task::LocalSet::new();
-                local.run_until(
-                    ipc_mining::mine_block_ipc(&socket_path, &script_bytes, cached)
-                ).await
-            }).with_context(|| format!("IPC mining failed for block '{label}'"))?;
+            let solution = rt
+                .block_on(async {
+                    let local = tokio::task::LocalSet::new();
+                    local
+                        .run_until(ipc_mining::mine_block_ipc(
+                            &socket_path,
+                            &script_bytes,
+                            cached,
+                        ))
+                        .await
+                })
+                .with_context(|| format!("IPC mining failed for block '{label}'"))?;
 
             if cached.is_none() {
                 cache.insert(label, solution);
@@ -333,7 +365,10 @@ impl<'a> RpcWallet<'a> {
 
             for tx in &raw_txs {
                 if tx.confirmations < 1 {
-                    eprintln!("⚠️  Skipping unconfirmed transaction {} (no block hash yet)", tx.txid);
+                    eprintln!(
+                        "⚠️  Skipping unconfirmed transaction {} (no block hash yet)",
+                        tx.txid
+                    );
                     continue;
                 }
 
@@ -369,7 +404,8 @@ impl<'a> RpcWallet<'a> {
         }
 
         all_txs.sort_by(|a, b| {
-            a.block_time.cmp(&b.block_time)
+            a.block_time
+                .cmp(&b.block_time)
                 .then(a.block_height.cmp(&b.block_height))
                 .then(a.vout.cmp(&b.vout))
         });
@@ -377,7 +413,10 @@ impl<'a> RpcWallet<'a> {
         Ok(all_txs)
     }
 
-    pub fn get_receive_descriptors(&self, receive_addresses: &std::collections::HashSet<String>) -> Result<Vec<String>> {
+    pub fn get_receive_descriptors(
+        &self,
+        receive_addresses: &std::collections::HashSet<String>,
+    ) -> Result<Vec<String>> {
         #[derive(Deserialize)]
         struct ListDescriptorsResult {
             descriptors: Vec<DescriptorInfo>,
@@ -398,10 +437,10 @@ impl<'a> RpcWallet<'a> {
                 continue;
             }
             let range = desc_info.range.unwrap_or([0, 0]);
-            let derived: Vec<String> = self.wallet_call("deriveaddresses", &[
-                serde_json::json!(desc_info.desc),
-                serde_json::json!(range),
-            ])?;
+            let derived: Vec<String> = self.wallet_call(
+                "deriveaddresses",
+                &[serde_json::json!(desc_info.desc), serde_json::json!(range)],
+            )?;
             if derived.iter().any(|a| receive_addresses.contains(a)) {
                 // Build multipath descriptor by combining with matched change descriptor
                 let recv_bare = desc_info.desc.split('#').next().unwrap_or(&desc_info.desc);
@@ -428,8 +467,7 @@ impl<'a> RpcWallet<'a> {
         method: &str,
         params: &[serde_json::Value],
     ) -> Result<T> {
-        self.node
-            .rpc_call_wallet(Some(&self.name), method, params)
+        self.node.rpc_call_wallet(Some(&self.name), method, params)
     }
 }
 


### PR DESCRIPTION
100% vibe
0% tested

Uses https://github.com/Sjors/bitcoin/pull/115

TODO:
- [ ] use mempool.space or local node (depending on privacy need) to obtain missing info from BIP329 export (e.g. block timestamp, or block hash for transaction)
- [ ] test with other BIP329 wallets

---

Here’s what Codex thinks is left:

**Must Decide**
- Metadata enrichment fallback: when BIP329 lacks reliable chain context, use either a local node or mempool.space to fill missing `blockhash`, block height, and preferably true block timestamp. Local node should probably be the default/privacy-preserving path; mempool.space can be an explicit convenience mode.
- Core export expectation: either improve Sjors/bitcoin#115 so `bitcoin-wallet exportlabels` reliably emits block height and block time, or keep btc-accounting tolerant and enrich after import.

**Implementation Left**
- Add a resolver layer for BIP329 imports that can fill missing/weak fields from `txid`.
- Decide how strict `--bitcoin-core-bip329` should be: fail loudly if accounting-critical fields are missing, or enrich when configured.
- Add CLI/docs for `--bitcoin-core-bip329`, including privacy warning for public API lookup.
- Add tests for degraded exports: missing height, missing blockhash, wallet-time vs block-time, and maybe standard BIP329 label-only files.

**Nice To Have**
- More regtest scenarios: self-send/change, unconfirmed/conflicted/RBF, multiple descriptors/accounts.
- A Core-side follow-up to make the export fully self-contained for accounting, so btc-accounting does not need lookups for Core exports.

Current branch/PR already covers the main POC: real `bitcoin-wallet exportlabels`, parser, CLI source, and RPC-vs-BIP329 equivalence test. The biggest remaining question is the enrichment strategy from PR #9.